### PR TITLE
Test OpenTofu workflow with S3 plan storage

### DIFF
--- a/.github/workflows/opentofu.yml
+++ b/.github/workflows/opentofu.yml
@@ -18,6 +18,9 @@ jobs:
   plan:
     name: 'OpenTofu Plan'
     runs-on: ubuntu-latest
+    outputs:
+      plan_hash: ${{ steps.plan.outputs.plan_hash }}
+      plan_key: ${{ steps.plan.outputs.plan_key }}
 
     defaults:
       run:
@@ -55,23 +58,33 @@ jobs:
       id: validate
       run: tofu validate -no-color
 
+    - name: Setup Linode CLI
+      uses: linode/action-linode-cli@v1
+      with:
+        token: ${{ secrets.LINODE_TOKEN }}
+
     - name: OpenTofu Plan
       id: plan
       run: |
         tofu plan -no-color -input=false -out=tfplan
-        tofu show -no-color tfplan > plan-output.txt
+        tofu show -no-color tfplan > plan-raw.txt
+        
+        # Post-process plan output to fix diff highlighting
+        sed -E 's/^(\s+)(\+|\-|\~)/\2\1/' plan-raw.txt > plan-output.txt
+        
+        # Generate checksum and upload plan to Object Storage
+        PLAN_HASH=$(sha256sum tfplan | cut -d' ' -f1)
+        PLAN_KEY="plans/${GITHUB_SHA}-${GITHUB_RUN_ID}.tfplan"
+        
+        linode-cli obj put tfplan andyleap-dev-tf/$PLAN_KEY
+        
+        echo "plan_hash=$PLAN_HASH" >> $GITHUB_OUTPUT
+        echo "plan_key=$PLAN_KEY" >> $GITHUB_OUTPUT
       env:
         LINODE_TOKEN: ${{ secrets.LINODE_TOKEN }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       continue-on-error: true
 
-    - name: Upload Plan Artifact
-      if: steps.plan.outcome == 'success'
-      uses: actions/upload-artifact@v4
-      with:
-        name: terraform-plan
-        path: ./terraform/tfplan
-        retention-days: 5
 
     - name: Update Pull Request
       uses: actions/github-script@v7
@@ -88,7 +101,7 @@ jobs:
 
           <details><summary>Show Plan</summary>
 
-          \`\`\`hcl\n
+          \`\`\`diff\n
           ${planOutput}
           \`\`\`
 
@@ -142,14 +155,32 @@ jobs:
         echo "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID" >> $GITHUB_ENV
         echo "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY" >> $GITHUB_ENV
 
+    - name: Setup Linode CLI
+      uses: linode/action-linode-cli@v1
+      with:
+        token: ${{ secrets.LINODE_TOKEN }}
+
     - name: OpenTofu Init
       run: tofu init
 
-    - name: Download Plan Artifact
-      uses: actions/download-artifact@v4
-      with:
-        name: terraform-plan
-        path: ./terraform/
+    - name: Download and Verify Plan
+      run: |
+        # Download plan from Object Storage
+        PLAN_KEY="plans/${GITHUB_SHA}-${{ github.run_id }}.tfplan"
+        linode-cli obj get andyleap-dev-tf $PLAN_KEY --file tfplan
+        
+        # Verify checksum
+        DOWNLOADED_HASH=$(sha256sum tfplan | cut -d' ' -f1)
+        EXPECTED_HASH="${{ needs.plan.outputs.plan_hash }}"
+        
+        if [ "$DOWNLOADED_HASH" != "$EXPECTED_HASH" ]; then
+          echo "❌ Plan checksum mismatch!"
+          echo "Expected: $EXPECTED_HASH"
+          echo "Downloaded: $DOWNLOADED_HASH"
+          exit 1
+        fi
+        
+        echo "✅ Plan checksum verified: $DOWNLOADED_HASH"
 
     - name: OpenTofu Apply
       run: tofu apply -auto-approve -input=false tfplan

--- a/terraform/lke.tf
+++ b/terraform/lke.tf
@@ -1,4 +1,5 @@
-# LKE cluster
+# LKE cluster - testing workflow
+# This cluster runs the main workloads
 resource "linode_lke_cluster" "cluster" {
   label       = "cluster"
   k8s_version = "1.31"


### PR DESCRIPTION
🧪 **Testing Infrastructure Workflow**

This PR tests the complete OpenTofu workflow including:

- ✅ **Plan Generation**: OpenTofu creates execution plan on PR creation
- ✅ **S3 Storage**: Plan securely stored in private `andyleap-dev-tf` bucket  
- ✅ **Checksum Verification**: SHA256 hash ensures plan integrity
- ✅ **Diff Highlighting**: Post-processed output for better PR readability
- ✅ **Environment Protection**: Manual approval required before apply

## Changes
- Added documentation comments to LKE cluster configuration
- No infrastructure changes expected (comment-only change)

## Expected Behavior
1. **Plan job** should run automatically and post results
2. **Apply job** should wait for manual approval in `terraform` environment
3. Plan should show "No changes" since this is just a documentation update

Ready to test the full GitOps workflow! 🚀