### PR TITLE
Add passkey-auth-service deployment to auth namespace

### DIFF
--- a/auth/configmap.yaml
+++ b/auth/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: auth-config
+data:
+  rp_id: "auth.andyleap.dev"
+  rp_origin: "https://auth.andyleap.dev"
+  s3_domain: "us-east-1.linodeobjects.com"
+  s3_bucket: "andyleap-dev-auth"

--- a/auth/deployment.yaml
+++ b/auth/deployment.yaml
@@ -1,0 +1,80 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: passkey-auth
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: passkey-auth
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  revisionHistoryLimit: 5
+  template:
+    metadata:
+      labels:
+        app: passkey-auth
+    spec:
+      containers:
+      - name: passkey-auth
+        image: ghcr.io/andyleap/passkey-auth-service:latest
+        ports:
+        - name: https
+          containerPort: 8443
+        env:
+        - name: PORT
+          value: "8443"
+        - name: RP_ID
+          valueFrom:
+            configMapKeyRef:
+              name: auth-config
+              key: rp_id
+        - name: RP_ORIGIN
+          valueFrom:
+            configMapKeyRef:
+              name: auth-config
+              key: rp_origin
+        - name: STORAGE_MODE
+          value: "s3"
+        - name: SESSION_MODE
+          value: "redis"
+        - name: S3_DOMAIN
+          valueFrom:
+            configMapKeyRef:
+              name: auth-config
+              key: s3_domain
+        - name: S3_BUCKET
+          valueFrom:
+            configMapKeyRef:
+              name: auth-config
+              key: s3_bucket
+        - name: S3_KEY
+          valueFrom:
+            secretKeyRef:
+              name: auth-api-token
+              key: key
+        - name: S3_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: auth-api-token
+              key: secret
+        - name: REDIS_ADDR
+          value: "redis:6379"
+        resources:
+          requests:
+            memory: "128Mi"
+            cpu: "100m"
+          limits:
+            memory: "256Mi"
+            cpu: "200m"
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 65534
+          capabilities:
+            drop:
+              - ALL

--- a/auth/kustomization.yaml
+++ b/auth/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: auth
+
+resources:
+- deployment.yaml
+- service.yaml
+- configmap.yaml
+
+images:
+- name: ghcr.io/andyleap/passkey-auth-service:latest
+  digest: sha256:55807f5fe6e57e922ff23fa54501b4dfab0d97d8491b7d8a41551412e3091c24

--- a/auth/service.yaml
+++ b/auth/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: passkey-auth
+  annotations:
+    git.andyleap.dev/singress-target: auth.andyleap.dev
+spec:
+  type: ClusterIP
+  selector:
+    app: passkey-auth
+  ports:
+  - name: https
+    port: 8443
+    targetPort: https

--- a/cluster/auth.yaml
+++ b/cluster/auth.yaml
@@ -1,0 +1,21 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: auth
+  namespace: argocd
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: 'https://github.com/andyleap-cluster/cluster.git'
+    path: auth
+    targetRevision: master
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: auth
+  syncPolicy:
+    automated:
+      selfHeal: true
+    syncOptions:
+    - CreateNamespace=true

--- a/terraform/object-storage.tf
+++ b/terraform/object-storage.tf
@@ -12,6 +12,13 @@ resource "linode_object_storage_bucket" "tls_certs" {
   acl    = "private"
 }
 
+# Auth service bucket
+resource "linode_object_storage_bucket" "auth" {
+  region = "us-east"
+  label  = "andyleap-dev-auth"
+  acl    = "private"
+}
+
 # Object storage access keys for existing services
 resource "linode_object_storage_key" "singress" {
   label = "singress-production"
@@ -23,5 +30,17 @@ resource "linode_object_storage_key" "singress" {
   }
 
   depends_on = [linode_object_storage_bucket.tls_certs]
+}
+
+resource "linode_object_storage_key" "auth" {
+  label = "auth-production"
+
+  bucket_access {
+    bucket_name = "andyleap-dev-auth"
+    region      = "us-east"
+    permissions = "read_write"
+  }
+
+  depends_on = [linode_object_storage_bucket.auth]
 }
 

--- a/terraform/secrets.tf
+++ b/terraform/secrets.tf
@@ -29,3 +29,18 @@ resource "kubernetes_secret" "lkedns_api_token" {
   type = "Opaque"
 }
 
+# Auth service (Object storage access)
+resource "kubernetes_secret" "auth_api_token" {
+  metadata {
+    name      = "auth-api-token"
+    namespace = "auth"
+  }
+
+  data = {
+    key    = linode_object_storage_key.auth.access_key
+    secret = linode_object_storage_key.auth.secret_key
+  }
+
+  type = "Opaque"
+}
+


### PR DESCRIPTION
## Summary
- Add Linode Object Storage bucket (andyleap-dev-auth) and access key via Terraform
- Create Kubernetes secret for S3 credentials via Terraform  
- Deploy passkey-auth-service with Redis session storage and S3 data storage
- Configure service with singress routing for auth.andyleap.dev
- Add ArgoCD application manifest for GitOps deployment

## Infrastructure Changes
- **terraform/object-storage.tf**: New auth bucket and access key
- **terraform/secrets.tf**: New auth-api-token secret in auth namespace

## Application Changes  
- **auth/**: New service directory with deployment, service, configmap, and kustomization
- **cluster/auth.yaml**: New ArgoCD application manifest

## Documentation Updates
- **CLAUDE.md**: Updated with current services and added Terraform/OpenTofu workflow documentation

## Test plan
- [ ] Review Terraform plan output in PR comments
- [ ] Approve PR to trigger OpenTofu apply
- [ ] Verify auth service deploys successfully via ArgoCD
- [ ] Test service accessibility at https://auth.andyleap.dev

🤖 Generated with [Claude Code](https://claude.ai/code)