### PR TITLE
Add passkey-auth-service deployment to auth namespace (v2)

### DIFF
--- a/auth/deployment.yaml
+++ b/auth/deployment.yaml
@@ -72,9 +72,9 @@ spec:
             cpu: "200m"
         securityContext:
           allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
           runAsNonRoot: true
-          runAsUser: 65534
+          runAsUser: 1001
+          runAsGroup: 1001
           capabilities:
             drop:
               - ALL


### PR DESCRIPTION
## Summary
- Add Linode Object Storage bucket (andyleap-dev-auth) and access key via Terraform
- Create Kubernetes secret for S3 credentials via Terraform  
- Deploy passkey-auth-service with Redis session storage and S3 data storage
- Configure service with singress routing for auth.andyleap.dev
- Add ArgoCD application manifest for GitOps deployment
- **FIXED**: Container security context to use UID 1001 (passkey user) instead of 65534

## Infrastructure Changes
- **terraform/object-storage.tf**: New auth bucket and access key
- **terraform/secrets.tf**: New auth-api-token secret in auth namespace

## Application Changes  
- **auth/**: New service directory with deployment, service, configmap, and kustomization
- **cluster/auth.yaml**: New ArgoCD application manifest
- **Fixed security context**: Uses runAsUser: 1001 to match Dockerfile's passkey user

## Documentation Updates
- **CLAUDE.md**: Updated with current services and added Terraform/OpenTofu workflow documentation

## Container Fix
The previous version had a permissions error because it was trying to run as UID 65534 (nobody) but the Dockerfile creates and uses UID 1001 (passkey user). This version:
- Uses `runAsUser: 1001` and `runAsGroup: 1001` to match the container's expected user
- Removes `readOnlyRootFilesystem` that was causing permission issues
- Maintains security hardening with `capabilities.drop: ALL`

## Test plan
- [ ] Review Terraform plan output in PR comments
- [ ] Approve PR to trigger OpenTofu apply
- [ ] Verify auth service deploys successfully via ArgoCD without permission errors
- [ ] Test service accessibility at https://auth.andyleap.dev

🤖 Generated with [Claude Code](https://claude.ai/code)