### PR TITLE
Fix auth service environment variables to match config.go

### DIFF
--- a/auth/configmap.yaml
+++ b/auth/configmap.yaml
@@ -5,5 +5,5 @@ metadata:
 data:
   rp_id: "auth.andyleap.dev"
   rp_origin: "https://auth.andyleap.dev"
-  s3_domain: "us-east-1.linodeobjects.com"
+  s3_endpoint: "us-east-1.linodeobjects.com"
   s3_bucket: "andyleap-dev-auth"

--- a/auth/deployment.yaml
+++ b/auth/deployment.yaml
@@ -41,22 +41,22 @@ spec:
           value: "s3"
         - name: SESSION_MODE
           value: "redis"
-        - name: S3_DOMAIN
+        - name: S3_ENDPOINT
           valueFrom:
             configMapKeyRef:
               name: auth-config
-              key: s3_domain
+              key: s3_endpoint
         - name: S3_BUCKET
           valueFrom:
             configMapKeyRef:
               name: auth-config
               key: s3_bucket
-        - name: S3_KEY
+        - name: S3_ACCESS_KEY
           valueFrom:
             secretKeyRef:
               name: auth-api-token
               key: key
-        - name: S3_SECRET
+        - name: S3_SECRET_KEY
           valueFrom:
             secretKeyRef:
               name: auth-api-token


### PR DESCRIPTION
## Summary
Fix environment variable names in the auth service deployment to match what the passkey-auth-service actually expects based on its config.go file.

## Issues Found
The deployment was using incorrect environment variable names that don't match the service's configuration:

## Changes
- **S3_DOMAIN** → **S3_ENDPOINT** (matches `S3_ENDPOINT` in config.go)
- **S3_KEY** → **S3_ACCESS_KEY** (matches `S3_ACCESS_KEY` in config.go)  
- **S3_SECRET** → **S3_SECRET_KEY** (matches `S3_SECRET_KEY` in config.go)
- Updated ConfigMap key from `s3_domain` to `s3_endpoint`

## Files Modified
- `auth/deployment.yaml`: Updated environment variable names
- `auth/configmap.yaml`: Updated ConfigMap key to match deployment reference

## Root Cause
The original deployment was based on assumptions about the environment variable names rather than checking the actual service configuration in config.go.

## Test Plan
- [ ] Service should now properly read S3 configuration
- [ ] No more "environment variable not found" errors
- [ ] S3 storage should work correctly with Linode Object Storage

🤖 Generated with [Claude Code](https://claude.ai/code)