### PR TITLE
Add CouchDB deployment with GitOps integration

### DIFF
--- a/cluster/couchdb.yaml
+++ b/cluster/couchdb.yaml
@@ -1,0 +1,21 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: couchdb
+  namespace: argocd
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: 'https://github.com/andyleap-cluster/cluster.git'
+    path: couchdb
+    targetRevision: master
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: couchdb
+  syncPolicy:
+    automated:
+      selfHeal: true
+    syncOptions:
+    - CreateNamespace=true

--- a/couchdb/deployment.yaml
+++ b/couchdb/deployment.yaml
@@ -1,0 +1,58 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: couchdb
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: couchdb
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  revisionHistoryLimit: 1
+  template:
+    metadata:
+      labels:
+        app: couchdb
+    spec:
+      securityContext:
+        runAsUser: 5984
+        runAsGroup: 5984
+        fsGroup: 5984
+      containers:
+      - name: couchdb
+        image: couchdb:3.3.3
+        ports:
+        - name: couchdb
+          containerPort: 5984
+        env:
+        - name: COUCHDB_USER
+          value: "admin"
+        - name: COUCHDB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: couchdb-secret
+              key: password
+        volumeMounts:
+        - name: couchdb-data
+          mountPath: /opt/couchdb/data
+        resources:
+          requests:
+            memory: "256Mi"
+            cpu: "100m"
+          limits:
+            memory: "512Mi"
+            cpu: "200m"
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: false
+      volumes:
+      - name: couchdb-data
+        persistentVolumeClaim:
+          claimName: couchdb-data

--- a/couchdb/kustomization.yaml
+++ b/couchdb/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: couchdb
+
+resources:
+- deployment.yaml
+- service.yaml
+- pvc.yaml
+
+images:
+- name: couchdb:3.3.3
+  digest: sha256:dff5e7bb64e99b5b6ad8ece26c4014eb9a17e07e20af84227e4c3ff8e2f7adf7

--- a/couchdb/pvc.yaml
+++ b/couchdb/pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: couchdb-data
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi

--- a/couchdb/service.yaml
+++ b/couchdb/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: couchdb
+spec:
+  type: ClusterIP
+  selector:
+    app: couchdb
+  ports:
+  - name: couchdb
+    port: 5984
+    targetPort: couchdb


### PR DESCRIPTION
## Summary
- Add complete CouchDB deployment configuration using established cluster patterns
- Create ArgoCD application manifest for automated GitOps deployment
- Configure security best practices and persistent data storage

## Changes
- **couchdb/** directory with Kustomize configuration
  - `deployment.yaml`: CouchDB 3.3.3 with security context (user 5984), resource limits, and PVC mount
  - `service.yaml`: ClusterIP service exposing port 5984
  - `pvc.yaml`: 10Gi persistent volume claim for data storage
  - `kustomization.yaml`: Image configuration with SHA256 digest
- **cluster/couchdb.yaml**: ArgoCD application manifest with automated sync and namespace creation

## Security Features
- Runs as dedicated CouchDB user (5984:5984)
- Drops all capabilities and disables privilege escalation
- Uses immutable image deployment with SHA256 digest
- Follows `revisionHistoryLimit: 1` pattern

## Test Plan
- [ ] Verify ArgoCD picks up the new application after merge
- [ ] Confirm CouchDB pod starts successfully in `couchdb` namespace
- [ ] Check persistent volume is correctly mounted
- [ ] Validate service accessibility within cluster
- [ ] Test admin login with configured credentials

🤖 Generated with [Claude Code](https://claude.ai/code)