### PR TITLE
Update CouchDB to latest version 3.5.0

### DIFF
--- a/couchdb/deployment.yaml
+++ b/couchdb/deployment.yaml
@@ -24,7 +24,7 @@ spec:
         fsGroup: 5984
       containers:
       - name: couchdb
-        image: couchdb:3.3.3
+        image: couchdb:3.5.0
         ports:
         - name: couchdb
           containerPort: 5984

--- a/couchdb/kustomization.yaml
+++ b/couchdb/kustomization.yaml
@@ -9,5 +9,5 @@ resources:
 - pvc.yaml
 
 images:
-- name: couchdb:3.3.3
-  digest: sha256:dff5e7bb64e99b5b6ad8ece26c4014eb9a17e07e20af84227e4c3ff8e2f7adf7
+- name: couchdb:3.5.0
+  digest: sha256:2f27666c837cb9096c95e3cbd1c125651c0fa6a92594ffc9268671e4d065d6a9


### PR DESCRIPTION
## Summary
- Upgrade CouchDB from version 3.3.3 to latest 3.5.0 (released May 2025)
- Fix incorrect SHA256 digest that was causing image pull failures
- Update image references in both deployment.yaml and kustomization.yaml

## Changes
- **couchdb/deployment.yaml**: Updated image tag from `couchdb:3.3.3` to `couchdb:3.5.0`
- **couchdb/kustomization.yaml**: Updated image digest to correct SHA256 for 3.5.0 release

## Test plan
- [ ] Verify ArgoCD can successfully pull and deploy the updated CouchDB image
- [ ] Confirm CouchDB pod starts successfully with new version
- [ ] Validate existing data persistence after upgrade

🤖 Generated with [Claude Code](https://claude.ai/code)