### PR TITLE
Add Linode DNS solver via webhook integration

### DIFF
--- a/cert-manager-webhook-linode/values.yaml
+++ b/cert-manager-webhook-linode/values.yaml
@@ -1,0 +1,29 @@
+# cert-manager-webhook-linode configuration
+
+# Group name used in ClusterIssuer/Issuer webhook config
+groupName: acme.slicen.me
+
+# Linode API credentials secret configuration
+# This should match the secret created by Terraform
+secretName: linode-credentials
+secretKey: token
+
+# Container image
+image:
+  repository: slicen/cert-manager-webhook-linode
+  tag: v0.2.0
+  pullPolicy: IfNotPresent
+
+# Service configuration
+service:
+  type: ClusterIP
+  port: 443
+
+# Resource limits
+resources:
+  requests:
+    cpu: 10m
+    memory: 32Mi
+  limits:
+    cpu: 100m
+    memory: 64Mi

--- a/cert-manager/clusterissuer.yaml
+++ b/cert-manager/clusterissuer.yaml
@@ -10,7 +10,6 @@ spec:
       name: letsencrypt-account-key
     solvers:
       - dns01:
-          linode:
-            apiKeySecretRef:
-              name: linode-dns-token
-              key: api-token
+          webhook:
+            solverName: linode
+            groupName: acme.slicen.me

--- a/cluster/cert-manager-webhook-linode.yaml
+++ b/cluster/cert-manager-webhook-linode.yaml
@@ -1,0 +1,27 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cert-manager-webhook-linode
+  namespace: argocd
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  sources:
+    - repoURL: 'https://github.com/slicen/cert-manager-webhook-linode.git'
+      targetRevision: v0.2.0
+      path: deploy/cert-manager-webhook-linode
+      helm:
+        valueFiles:
+          - $values/cert-manager-webhook-linode/values.yaml
+    - repoURL: 'https://github.com/andyleap-cluster/cluster.git'
+      targetRevision: master
+      ref: values
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: cert-manager
+  syncPolicy:
+    automated:
+      selfHeal: true
+    syncOptions:
+    - CreateNamespace=true

--- a/terraform/secrets.tf
+++ b/terraform/secrets.tf
@@ -6,14 +6,15 @@ resource "linode_token" "cert_manager" {
   scopes = "domains:read_write"
 }
 
-# Create Kubernetes secret for cert-manager to access Linode DNS API
+# Create Kubernetes secret for cert-manager webhook to access Linode DNS API
+# The webhook expects secret name "linode-credentials" with key "token"
 resource "kubernetes_secret" "cert_manager_linode" {
   metadata {
-    name      = "linode-dns-token"
+    name      = "linode-credentials"
     namespace = "cert-manager"
   }
 
   data = {
-    "api-token" = linode_token.cert_manager.token
+    "token" = linode_token.cert_manager.token
   }
 }


### PR DESCRIPTION
Linode is not a natively supported in-tree DNS provider in cert-manager, so we need to use a webhook solver instead. This adds:

- ArgoCD application for cert-manager-webhook-linode (v0.2.0)
- Values file configuring the webhook for our cluster
- Updated ClusterIssuer to use webhook solver with groupName acme.slicen.me
- Updated Terraform secret to use expected name/key format (linode-credentials/token)