### PR TITLE
Fix webhook values structure and disable unsupported --v flag

### DIFF
--- a/cert-manager-webhook-linode/values.yaml
+++ b/cert-manager-webhook-linode/values.yaml
@@ -1,25 +1,30 @@
 # cert-manager-webhook-linode configuration
 
-# Group name used in ClusterIssuer/Issuer webhook config
-groupName: acme.slicen.me
+api:
+  # Group name used in ClusterIssuer/Issuer webhook config
+  groupName: acme.slicen.me
 
-# Linode API credentials secret configuration
-# This should match the secret created by Terraform
-secretName: linode-credentials
-secretKey: token
+certManager:
+  namespace: cert-manager
+  serviceAccountName: cert-manager
 
-# Container image
+deployment:
+  # Linode API credentials secret configuration
+  # This should match the secret created by Terraform
+  secretName: linode-credentials
+  secretKey: token
+  # Disable logLevel - the webhook binary doesn't support --v flag
+  logLevel: ""
+
 image:
-  repository: slicen/cert-manager-webhook-linode
-  tag: v0.2.0
+  repository: linode/cert-manager-webhook-linode
+  tag: v0.3.0
   pullPolicy: IfNotPresent
 
-# Service configuration
 service:
   type: ClusterIP
   port: 443
 
-# Resource limits
 resources:
   requests:
     cpu: 10m

--- a/cluster/cert-manager-webhook-linode.yaml
+++ b/cluster/cert-manager-webhook-linode.yaml
@@ -8,8 +8,8 @@ metadata:
 spec:
   project: default
   sources:
-    - repoURL: 'https://github.com/slicen/cert-manager-webhook-linode.git'
-      targetRevision: v0.2.0
+    - repoURL: 'https://github.com/linode/cert-manager-webhook-linode.git'
+      targetRevision: v0.3.0
       path: deploy/cert-manager-webhook-linode
       helm:
         valueFiles:


### PR DESCRIPTION
- Use official linode/cert-manager-webhook-linode repo and image (v0.3.0)
- Correct values.yaml structure to match Helm chart expectations
- Disable logLevel flag - the webhook binary doesn't support --v