### PR TITLE
Drop redundant top-level source from multi-source Applications

### DIFF
--- a/cluster/argocd.yaml
+++ b/cluster/argocd.yaml
@@ -7,13 +7,6 @@ metadata:
   - resources-finalizer.argocd.argoproj.io
 spec:
   project: default
-  source:
-    repoURL: 'https://argoproj.github.io/argo-helm'
-    chart: argo-cd
-    targetRevision: 8.3.3
-    helm:
-      valueFiles:
-        - $values/argocd/values.yaml
   sources:
     - repoURL: 'https://argoproj.github.io/argo-helm'
       chart: argo-cd

--- a/cluster/cert-manager.yaml
+++ b/cluster/cert-manager.yaml
@@ -7,13 +7,6 @@ metadata:
   - resources-finalizer.argocd.argoproj.io
 spec:
   project: default
-  source:
-    repoURL: 'https://charts.jetstack.io'
-    chart: cert-manager
-    targetRevision: v1.16.2
-    helm:
-      valueFiles:
-        - $values/cert-manager/values.yaml
   sources:
     - repoURL: 'https://charts.jetstack.io'
       chart: cert-manager

--- a/cluster/traefik.yaml
+++ b/cluster/traefik.yaml
@@ -7,13 +7,6 @@ metadata:
   - resources-finalizer.argocd.argoproj.io
 spec:
   project: default
-  source:
-    repoURL: 'https://traefik.github.io/charts'
-    chart: traefik
-    targetRevision: 34.4.1
-    helm:
-      valueFiles:
-        - $values/traefik/values.yaml
   sources:
     - repoURL: 'https://traefik.github.io/charts'
       chart: traefik


### PR DESCRIPTION
## Summary

Addresses 2 of the 3 Copilot review comments from #30, plus a drive-by fix to [cluster/traefik.yaml](cluster/traefik.yaml) which had the same pattern (it's where I copied it from in the original PR).

ArgoCD multi-source Applications only need `sources:`. The top-level `source:` block was duplicating the first `sources[]` entry verbatim — easy to drift, unclear which is authoritative.

## On the third Copilot comment (declined)

Copilot also suggested rewriting `cert-manager/values.yaml`'s `extraObjects` from `- |` block-scalar strings into a normal mapping (as [argocd/values.yaml](argocd/values.yaml) does). That suggestion would re-break the chart: cert-manager's `extras-objects.yaml` template is `{{ range .Values.extraObjects }}{{ tpl . $ }}{{ end }}` — `tpl` requires a string. I hit `expected string; got map[string]interface{}` empirically during the original PR's verification, which is why the string form was chosen. argo-cd's `extraObjects` template accepts maps; cert-manager's does not. Chart-specific, not interchangeable.

## Test plan

- [ ] ArgoCD reconciles all three Applications (argocd, cert-manager, traefik) to `Synced/Healthy` after merge
- [ ] No drift in deployed resources — only the Application manifest itself changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)