### PR TITLE
Make HTTPRoute defaults explicit to avoid ArgoCD drift

### DIFF
--- a/argocd/values.yaml
+++ b/argocd/values.yaml
@@ -26,7 +26,9 @@ extraObjects:
       namespace: argocd
     spec:
       parentRefs:
-        - name: traefik-gateway
+        - group: gateway.networking.k8s.io
+          kind: Gateway
+          name: traefik-gateway
           namespace: traefik
           sectionName: websecure
       hostnames:
@@ -37,8 +39,11 @@ extraObjects:
                 type: PathPrefix
                 value: /
           backendRefs:
-            - name: argocd-server
+            - group: ""
+              kind: Service
+              name: argocd-server
               port: 80
+              weight: 1
 
   - apiVersion: gateway.networking.k8s.io/v1
     kind: HTTPRoute
@@ -47,7 +52,9 @@ extraObjects:
       namespace: argocd
     spec:
       parentRefs:
-        - name: traefik-gateway
+        - group: gateway.networking.k8s.io
+          kind: Gateway
+          name: traefik-gateway
           namespace: traefik
           sectionName: web
       hostnames:


### PR DESCRIPTION
## Summary

Persistent OutOfSync on the `argocd` Application after the Helm migration. The Gateway API admission server-side-defaults `parentRefs[].group=gateway.networking.k8s.io`, `parentRefs[].kind=Gateway`, `backendRefs[].kind=Service`, and `backendRefs[].weight=1` when the source omits them. ArgoCD compares the chart-rendered manifest against the live object including those defaults, sees the extra fields, and reports drift forever.

Fix: spell the defaults explicitly in [argocd/values.yaml](argocd/values.yaml) so source and cluster state are byte-identical after the admission webhook is done with them.

## Test plan

- [ ] Merge, then check `kubectl get application argocd -n argocd` reports `Synced/Healthy`
- [ ] If still OutOfSync, the remaining diff is something else — use `argocd app diff argocd` to see what

## Backstory

The migration to Helm in #30 + the partial-sync state during cluster recovery left the argocd App OutOfSync. The recovery is complete (all pods running on the chart-rendered Deployments, cert-manager and traefik fully synced), but the argocd Application kept showing OutOfSync on the two HTTPRoutes in `extraObjects`. This change resolves that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)