### PR TITLE
Install Kargo via ArgoCD (Phase 3)

### DIFF
--- a/cluster/kargo.yaml
+++ b/cluster/kargo.yaml
@@ -1,0 +1,32 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kargo
+  namespace: argocd
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  sources:
+    - repoURL: 'ghcr.io/akuity/kargo-charts'
+      chart: kargo
+      targetRevision: 1.1.1
+      helm:
+        valueFiles:
+          - $values/kargo/values.yaml
+    - repoURL: 'https://github.com/andyleap-cluster/cluster.git'
+      targetRevision: master
+      ref: values
+    - repoURL: 'https://github.com/andyleap-cluster/cluster.git'
+      targetRevision: master
+      path: kargo/extras
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: kargo
+  syncPolicy:
+    automated:
+      selfHeal: true
+      prune: true
+    syncOptions:
+    - CreateNamespace=true
+    - ServerSideApply=true

--- a/kargo/extras/certificate.yaml
+++ b/kargo/extras/certificate.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: kargo-tls
+  namespace: kargo
+spec:
+  secretName: kargo-tls
+  issuerRef:
+    name: letsencrypt
+    kind: ClusterIssuer
+  dnsNames:
+    - kargo.andyleap.dev

--- a/kargo/extras/httproute.yaml
+++ b/kargo/extras/httproute.yaml
@@ -1,0 +1,50 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: kargo
+  namespace: kargo
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: traefik-gateway
+      namespace: traefik
+      sectionName: websecure
+  hostnames:
+    - kargo.andyleap.dev
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - group: ""
+          kind: Service
+          name: kargo-api
+          port: 80
+          weight: 1
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: kargo-redirect
+  namespace: kargo
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: traefik-gateway
+      namespace: traefik
+      sectionName: web
+  hostnames:
+    - kargo.andyleap.dev
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            statusCode: 301

--- a/kargo/extras/kustomization.yaml
+++ b/kargo/extras/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: kargo
+
+resources:
+  - certificate.yaml
+  - httproute.yaml
+  - referencegrant.yaml

--- a/kargo/extras/referencegrant.yaml
+++ b/kargo/extras/referencegrant.yaml
@@ -1,0 +1,14 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: allow-traefik-gateway
+  namespace: kargo
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      namespace: traefik
+  to:
+    - group: ""
+      kind: Secret
+      name: kargo-tls

--- a/kargo/values.yaml
+++ b/kargo/values.yaml
@@ -1,0 +1,36 @@
+# Kargo Helm chart values
+# https://github.com/akuity/kargo/tree/main/charts/kargo
+
+crds:
+  install: true
+  keep: true
+
+api:
+  # Admin account disabled until Phase 4 wires up the secret via Terraform.
+  # Kargo CRDs (Project/Warehouse/Stage) still work via kubectl in the meantime.
+  adminAccount:
+    enabled: false
+  host: kargo.andyleap.dev
+  service:
+    type: ClusterIP
+  ingress:
+    enabled: false
+  # TLS terminated upstream by Traefik (Gateway API HTTPRoute, letsencrypt cert).
+  # Kargo API serves plain HTTP on port 80 inside the cluster.
+  tls:
+    enabled: false
+
+webhooksServer:
+  tls:
+    selfSignedCert: true
+
+controller:
+  argocd:
+    integrationEnabled: true
+    namespace: argocd
+
+managementController:
+  enabled: true
+
+garbageCollector:
+  enabled: true


### PR DESCRIPTION
## Summary

Phase 3 of the Kargo rollout. Adds an ArgoCD Application that installs Kargo 1.1.1 from `ghcr.io/akuity/kargo-charts`.

The Kargo chart doesn't expose `extraObjects`, so the Gateway API resources for `kargo.andyleap.dev` live as a separate path in [kargo/extras/](kargo/extras/) and are pulled in as a second deployable source on the same Application. Sets a precedent we can apply to argocd/cert-manager/traefik later (their `extraObjects` blocks could move to `<app>/extras/` for consistency and better tooling — separate PR).

## Notable choices

- **Admin auth disabled this phase** (`api.adminAccount.enabled: false`). Will be re-enabled in Phase 4 alongside the Terraform-managed deploy-key Secret + admin Secret.
- **API TLS off** (`api.tls.enabled: false`). Traefik terminates the letsencrypt cert on the HTTPRoute and proxies plain HTTP to the kargo-api Service. Avoids TLS-in-TLS through the Gateway. Webhook server keeps cert-manager's self-signed cert (internal-only traffic).
- `crds.keep: true` so an ArgoCD prune wouldn't delete CRDs and orphan Projects/Stages.

## Test plan

- [ ] After merge, ArgoCD shows `kargo` Application `Synced/Healthy`
- [ ] `kubectl get pods -n kargo` shows kargo-api, kargo-controller, kargo-management-controller, kargo-webhooks-server all Running
- [ ] `kubectl get crds | grep kargo` shows Project/Warehouse/Stage/Promotion/PromotionTask/ClusterPromotionTask CRDs
- [ ] `kargo.andyleap.dev` resolves and serves the Kargo login screen (will be empty / no-auth this phase)
- [ ] `kubectl get apiservice | grep -v True` shows no broken APIServices (lesson learned from cert-manager incident)

🤖 Generated with [Claude Code](https://claude.com/claude-code)