### PR TITLE
Ignore k8s-defaulted fields on Kargo Deployments/CronJob

### DIFF
--- a/cluster/kargo.yaml
+++ b/cluster/kargo.yaml
@@ -30,3 +30,12 @@ spec:
     syncOptions:
     - CreateNamespace=true
     - ServerSideApply=true
+  ignoreDifferences:
+    - group: apps
+      kind: Deployment
+      managedFieldsManagers:
+        - kube-controller-manager
+    - group: batch
+      kind: CronJob
+      managedFieldsManagers:
+        - kube-controller-manager


### PR DESCRIPTION
## Summary

The Kargo Helm chart 1.1.1 doesn't explicitly set common Deployment defaults — `progressDeadlineSeconds`, `revisionHistoryLimit`, `strategy.rollingUpdate.maxSurge/maxUnavailable`, plus `template.spec` defaults like `terminationGracePeriodSeconds`, `dnsPolicy`, `restartPolicy`, `schedulerName`, probe `periodSeconds/successThreshold/timeoutSeconds/failureThreshold`, container `terminationMessagePolicy/Path`, `env.resourceFieldRef.divisor`. The API server fills them in; ArgoCD sees them on the live object and reports persistent drift on all 4 Kargo Deployments and the garbage-collector CronJob.

`kubectl diff` against the rendered chart returns empty — confirms the drift is purely k8s defaulting, not a real spec divergence.

`managedFieldsManagers` is the targeted lever for this: tell ArgoCD to ignore fields owned by `kube-controller-manager` on these resources. Cleaner than listing 15+ JSON paths in `ignoreDifferences`.

## Test plan

- [ ] After merge, `kargo` Application reaches `Synced/Healthy`
- [ ] `kubectl get pods -n kargo` still shows all 4 pods Running (no churn from this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)