### PR TITLE
Drop HTTP-to-HTTPS redirect HTTPRoutes on .dev hosts

### DIFF
--- a/argocd/extras/httproute.yaml
+++ b/argocd/extras/httproute.yaml
@@ -23,28 +23,3 @@ spec:
           name: argocd-server
           port: 80
           weight: 1
----
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
-metadata:
-  name: argocd-redirect
-  namespace: argocd
-spec:
-  parentRefs:
-    - group: gateway.networking.k8s.io
-      kind: Gateway
-      name: traefik-gateway
-      namespace: traefik
-      sectionName: web
-  hostnames:
-    - argocd.andyleap.dev
-  rules:
-    - matches:
-        - path:
-            type: PathPrefix
-            value: /
-      filters:
-        - type: RequestRedirect
-          requestRedirect:
-            scheme: https
-            statusCode: 301

--- a/kargo/extras/httproute.yaml
+++ b/kargo/extras/httproute.yaml
@@ -23,28 +23,3 @@ spec:
           name: kargo-api
           port: 80
           weight: 1
----
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
-metadata:
-  name: kargo-redirect
-  namespace: kargo
-spec:
-  parentRefs:
-    - group: gateway.networking.k8s.io
-      kind: Gateway
-      name: traefik-gateway
-      namespace: traefik
-      sectionName: web
-  hostnames:
-    - kargo.andyleap.dev
-  rules:
-    - matches:
-        - path:
-            type: PathPrefix
-            value: /
-      filters:
-        - type: RequestRedirect
-          requestRedirect:
-            scheme: https
-            statusCode: 301


### PR DESCRIPTION
## Summary

The `.dev` gTLD is HSTS-preloaded in every major browser, so browsers upgrade `http://` to `https://` before sending the request. The `argocd-redirect` and `kargo-redirect` HTTPRoutes on the `web` (port 80) listener never get hit by real traffic — they're dead code. Drop them.

The `websecure` (port 443) HTTPRoutes are unchanged.

## Test plan

- [ ] After merge, ArgoCD reconciles `argocd` and `kargo` Apps to Synced/Healthy
- [ ] `https://argocd.andyleap.dev` and `https://kargo.andyleap.dev` still serve
- [ ] `kubectl get httproute -A` no longer shows `argocd-redirect` or `kargo-redirect`

🤖 Generated with [Claude Code](https://claude.com/claude-code)