### PR TITLE
Add plaintext Kargo admin Secret for kubectl retrieval

### DIFF
--- a/terraform/kargo.tf
+++ b/terraform/kargo.tf
@@ -65,3 +65,21 @@ output "kargo_admin_password" {
   sensitive = true
   description = "Initial Kargo admin password. Retrieve with: tofu output -raw kargo_admin_password"
 }
+
+# Plaintext copy of the admin credentials for easy retrieval via kubectl.
+# Not consumed by the chart — kargo-api reads its hash + signing key from
+# the `kargo-api` Secret above.
+#
+#   kubectl -n kargo get secret kargo-admin-credentials \
+#     -o jsonpath='{.data.password}' | base64 -d
+resource "kubernetes_secret" "kargo_admin_credentials" {
+  metadata {
+    name      = "kargo-admin-credentials"
+    namespace = "kargo"
+  }
+
+  data = {
+    username = "admin"
+    password = random_password.kargo_admin.result
+  }
+}


### PR DESCRIPTION
## Summary

Adds a parallel `kargo-admin-credentials` Secret in the kargo namespace containing the username/plaintext password. Lets you fetch the admin password without poking at tfstate:

```
kubectl -n kargo get secret kargo-admin-credentials \
  -o jsonpath='{.data.password}' | base64 -d
```

The chart still reads its bcrypt hash and token signing key from the existing `kargo-api` Secret — this is purely a convenience copy.

## Test plan

- [ ] After apply, `kubectl -n kargo get secret kargo-admin-credentials` exists with `username` and `password` keys
- [ ] The decoded `password` value matches `tofu output -raw kargo_admin_password`

🤖 Generated with [Claude Code](https://claude.com/claude-code)