### PR TITLE
Define Kargo Projects, Warehouses, and Stages (Phase 5)

### DIFF
--- a/cluster/argocd.yaml
+++ b/cluster/argocd.yaml
@@ -3,6 +3,8 @@ kind: Application
 metadata:
   name: argocd
   namespace: argocd
+  annotations:
+    kargo.akuity.io/authorized-stage: "kargo-argocd:main"
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/cluster/cert-manager-webhook-linode.yaml
+++ b/cluster/cert-manager-webhook-linode.yaml
@@ -3,6 +3,8 @@ kind: Application
 metadata:
   name: cert-manager-webhook-linode
   namespace: argocd
+  annotations:
+    kargo.akuity.io/authorized-stage: "kargo-cert-manager-webhook-linode:main"
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/cluster/cert-manager.yaml
+++ b/cluster/cert-manager.yaml
@@ -3,6 +3,8 @@ kind: Application
 metadata:
   name: cert-manager
   namespace: argocd
+  annotations:
+    kargo.akuity.io/authorized-stage: "kargo-cert-manager:main"
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/cluster/kargo-projects.yaml
+++ b/cluster/kargo-projects.yaml
@@ -1,17 +1,15 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: gateway-api
+  name: kargo-projects
   namespace: argocd
-  annotations:
-    kargo.akuity.io/authorized-stage: "kargo-gateway-api:main"
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:
   project: default
   source:
     repoURL: 'https://github.com/andyleap-cluster/cluster.git'
-    path: gateway-api
+    path: kargo-projects
     targetRevision: master
   destination:
     server: 'https://kubernetes.default.svc'

--- a/cluster/traefik.yaml
+++ b/cluster/traefik.yaml
@@ -3,6 +3,8 @@ kind: Application
 metadata:
   name: traefik
   namespace: argocd
+  annotations:
+    kargo.akuity.io/authorized-stage: "kargo-traefik:main"
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/kargo-projects/argocd/kustomization.yaml
+++ b/kargo-projects/argocd/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - project.yaml
+  - warehouse.yaml
+  - stage.yaml

--- a/kargo-projects/argocd/project.yaml
+++ b/kargo-projects/argocd/project.yaml
@@ -1,0 +1,8 @@
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Project
+metadata:
+  name: kargo-argocd
+spec:
+  promotionPolicies:
+    - stage: main
+      autoPromotionEnabled: true

--- a/kargo-projects/argocd/stage.yaml
+++ b/kargo-projects/argocd/stage.yaml
@@ -46,8 +46,3 @@ spec:
           config:
             path: ./out
             targetBranch: live
-        - uses: argocd-update
-          config:
-            apps:
-              - name: argocd
-                namespace: argocd

--- a/kargo-projects/argocd/stage.yaml
+++ b/kargo-projects/argocd/stage.yaml
@@ -1,0 +1,53 @@
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+metadata:
+  name: main
+  namespace: kargo-argocd
+spec:
+  requestedFreight:
+    - origin:
+        kind: Warehouse
+        name: argocd
+      sources:
+        direct: true
+  promotionTemplate:
+    spec:
+      steps:
+        - uses: git-clone
+          config:
+            repoURL: git@github.com:andyleap-cluster/cluster.git
+            checkout:
+              - branch: master
+                path: ./src
+              - branch: live
+                create: true
+                path: ./out
+        # Sync this stage's owned slice from master to live, then apply the bump on top.
+        - uses: copy
+          config:
+            inPath: ./src/cluster/argocd.yaml
+            outPath: ./out/cluster/argocd.yaml
+        - uses: copy
+          config:
+            inPath: ./src/argocd
+            outPath: ./out/argocd
+        - uses: yaml-update
+          config:
+            path: ./out/cluster/argocd.yaml
+            updates:
+              - key: spec.sources.0.targetRevision
+                value: ${{ chartFrom("https://argoproj.github.io/argo-helm", "argo-cd").Version }}
+        - uses: git-commit
+          config:
+            path: ./out
+            message: |
+              kargo: bump argocd to chart ${{ chartFrom("https://argoproj.github.io/argo-helm", "argo-cd").Version }}
+        - uses: git-push
+          config:
+            path: ./out
+            targetBranch: live
+        - uses: argocd-update
+          config:
+            apps:
+              - name: argocd
+                namespace: argocd

--- a/kargo-projects/argocd/warehouse.yaml
+++ b/kargo-projects/argocd/warehouse.yaml
@@ -1,0 +1,11 @@
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Warehouse
+metadata:
+  name: argocd
+  namespace: kargo-argocd
+spec:
+  subscriptions:
+    - chart:
+        repoURL: https://argoproj.github.io/argo-helm
+        name: argo-cd
+        semverConstraint: ">=8.0.0 <9.0.0"

--- a/kargo-projects/cert-manager-webhook-linode/kustomization.yaml
+++ b/kargo-projects/cert-manager-webhook-linode/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - project.yaml
+  - warehouse.yaml
+  - stage.yaml

--- a/kargo-projects/cert-manager-webhook-linode/project.yaml
+++ b/kargo-projects/cert-manager-webhook-linode/project.yaml
@@ -1,0 +1,8 @@
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Project
+metadata:
+  name: kargo-cert-manager-webhook-linode
+spec:
+  promotionPolicies:
+    - stage: main
+      autoPromotionEnabled: true

--- a/kargo-projects/cert-manager-webhook-linode/stage.yaml
+++ b/kargo-projects/cert-manager-webhook-linode/stage.yaml
@@ -51,8 +51,3 @@ spec:
           config:
             path: ./out
             targetBranch: live
-        - uses: argocd-update
-          config:
-            apps:
-              - name: cert-manager-webhook-linode
-                namespace: argocd

--- a/kargo-projects/cert-manager-webhook-linode/stage.yaml
+++ b/kargo-projects/cert-manager-webhook-linode/stage.yaml
@@ -1,0 +1,58 @@
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+metadata:
+  name: main
+  namespace: kargo-cert-manager-webhook-linode
+spec:
+  requestedFreight:
+    - origin:
+        kind: Warehouse
+        name: cert-manager-webhook-linode
+      sources:
+        direct: true
+  promotionTemplate:
+    spec:
+      steps:
+        - uses: git-clone
+          config:
+            repoURL: git@github.com:andyleap-cluster/cluster.git
+            checkout:
+              - branch: master
+                path: ./src
+              - branch: live
+                create: true
+                path: ./out
+        - uses: copy
+          config:
+            inPath: ./src/cluster/cert-manager-webhook-linode.yaml
+            outPath: ./out/cluster/cert-manager-webhook-linode.yaml
+        - uses: copy
+          config:
+            inPath: ./src/cert-manager-webhook-linode
+            outPath: ./out/cert-manager-webhook-linode
+        - uses: yaml-update
+          config:
+            path: ./out/cluster/cert-manager-webhook-linode.yaml
+            updates:
+              - key: spec.sources.0.targetRevision
+                value: ${{ commitFrom("https://github.com/linode/cert-manager-webhook-linode.git").Tag }}
+        - uses: yaml-update
+          config:
+            path: ./out/cert-manager-webhook-linode/values.yaml
+            updates:
+              - key: image.tag
+                value: ${{ imageFrom("docker.io/linode/cert-manager-webhook-linode").Tag }}
+        - uses: git-commit
+          config:
+            path: ./out
+            message: |
+              kargo: bump cert-manager-webhook-linode to ${{ commitFrom("https://github.com/linode/cert-manager-webhook-linode.git").Tag }} / image ${{ imageFrom("docker.io/linode/cert-manager-webhook-linode").Tag }}
+        - uses: git-push
+          config:
+            path: ./out
+            targetBranch: live
+        - uses: argocd-update
+          config:
+            apps:
+              - name: cert-manager-webhook-linode
+                namespace: argocd

--- a/kargo-projects/cert-manager-webhook-linode/warehouse.yaml
+++ b/kargo-projects/cert-manager-webhook-linode/warehouse.yaml
@@ -1,0 +1,18 @@
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Warehouse
+metadata:
+  name: cert-manager-webhook-linode
+  namespace: kargo-cert-manager-webhook-linode
+spec:
+  subscriptions:
+    # The chart for this webhook is hosted in a git repo, not a chart registry,
+    # so we track the repo's git tags as the "chart version".
+    - git:
+        repoURL: https://github.com/linode/cert-manager-webhook-linode.git
+        commitSelectionStrategy: SemVer
+        allowTagsRegexes:
+          - "^v.*"
+    - image:
+        repoURL: docker.io/linode/cert-manager-webhook-linode
+        imageSelectionStrategy: SemVer
+        constraint: ">=0.3.0"

--- a/kargo-projects/cert-manager-webhook-linode/warehouse.yaml
+++ b/kargo-projects/cert-manager-webhook-linode/warehouse.yaml
@@ -11,8 +11,8 @@ spec:
         repoURL: https://github.com/linode/cert-manager-webhook-linode.git
         commitSelectionStrategy: SemVer
         allowTagsRegexes:
-          - "^v.*"
+          - "^v0\\..*"
     - image:
         repoURL: docker.io/linode/cert-manager-webhook-linode
         imageSelectionStrategy: SemVer
-        constraint: ">=0.3.0"
+        constraint: ">=0.3.0 <1.0.0"

--- a/kargo-projects/cert-manager/kustomization.yaml
+++ b/kargo-projects/cert-manager/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - project.yaml
+  - warehouse.yaml
+  - stage.yaml

--- a/kargo-projects/cert-manager/project.yaml
+++ b/kargo-projects/cert-manager/project.yaml
@@ -1,0 +1,8 @@
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Project
+metadata:
+  name: kargo-cert-manager
+spec:
+  promotionPolicies:
+    - stage: main
+      autoPromotionEnabled: true

--- a/kargo-projects/cert-manager/stage.yaml
+++ b/kargo-projects/cert-manager/stage.yaml
@@ -45,8 +45,3 @@ spec:
           config:
             path: ./out
             targetBranch: live
-        - uses: argocd-update
-          config:
-            apps:
-              - name: cert-manager
-                namespace: argocd

--- a/kargo-projects/cert-manager/stage.yaml
+++ b/kargo-projects/cert-manager/stage.yaml
@@ -1,0 +1,52 @@
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+metadata:
+  name: main
+  namespace: kargo-cert-manager
+spec:
+  requestedFreight:
+    - origin:
+        kind: Warehouse
+        name: cert-manager
+      sources:
+        direct: true
+  promotionTemplate:
+    spec:
+      steps:
+        - uses: git-clone
+          config:
+            repoURL: git@github.com:andyleap-cluster/cluster.git
+            checkout:
+              - branch: master
+                path: ./src
+              - branch: live
+                create: true
+                path: ./out
+        - uses: copy
+          config:
+            inPath: ./src/cluster/cert-manager.yaml
+            outPath: ./out/cluster/cert-manager.yaml
+        - uses: copy
+          config:
+            inPath: ./src/cert-manager
+            outPath: ./out/cert-manager
+        - uses: yaml-update
+          config:
+            path: ./out/cluster/cert-manager.yaml
+            updates:
+              - key: spec.sources.0.targetRevision
+                value: ${{ chartFrom("https://charts.jetstack.io", "cert-manager").Version }}
+        - uses: git-commit
+          config:
+            path: ./out
+            message: |
+              kargo: bump cert-manager to chart ${{ chartFrom("https://charts.jetstack.io", "cert-manager").Version }}
+        - uses: git-push
+          config:
+            path: ./out
+            targetBranch: live
+        - uses: argocd-update
+          config:
+            apps:
+              - name: cert-manager
+                namespace: argocd

--- a/kargo-projects/cert-manager/warehouse.yaml
+++ b/kargo-projects/cert-manager/warehouse.yaml
@@ -1,0 +1,11 @@
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Warehouse
+metadata:
+  name: cert-manager
+  namespace: kargo-cert-manager
+spec:
+  subscriptions:
+    - chart:
+        repoURL: https://charts.jetstack.io
+        name: cert-manager
+        semverConstraint: ">=1.16.0 <2.0.0"

--- a/kargo-projects/gateway-api/kustomization.yaml
+++ b/kargo-projects/gateway-api/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - project.yaml
+  - warehouse.yaml
+  - stage.yaml

--- a/kargo-projects/gateway-api/project.yaml
+++ b/kargo-projects/gateway-api/project.yaml
@@ -1,0 +1,8 @@
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Project
+metadata:
+  name: kargo-gateway-api
+spec:
+  promotionPolicies:
+    - stage: main
+      autoPromotionEnabled: true

--- a/kargo-projects/gateway-api/stage.yaml
+++ b/kargo-projects/gateway-api/stage.yaml
@@ -1,0 +1,54 @@
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+metadata:
+  name: main
+  namespace: kargo-gateway-api
+spec:
+  requestedFreight:
+    - origin:
+        kind: Warehouse
+        name: gateway-api
+      sources:
+        direct: true
+  promotionTemplate:
+    spec:
+      steps:
+        - uses: git-clone
+          config:
+            repoURL: git@github.com:andyleap-cluster/cluster.git
+            checkout:
+              - branch: master
+                path: ./src
+              - branch: live
+                create: true
+                path: ./out
+        - uses: copy
+          config:
+            inPath: ./src/cluster/gateway-api.yaml
+            outPath: ./out/cluster/gateway-api.yaml
+        - uses: copy
+          config:
+            inPath: ./src/gateway-api
+            outPath: ./out/gateway-api
+        # Rewrite the standard-install.yaml URL in kustomization.yaml to the
+        # newly-discovered git tag. resources.0 is the list element.
+        - uses: yaml-update
+          config:
+            path: ./out/gateway-api/kustomization.yaml
+            updates:
+              - key: resources.0
+                value: https://github.com/kubernetes-sigs/gateway-api/releases/download/${{ commitFrom("https://github.com/kubernetes-sigs/gateway-api.git").Tag }}/standard-install.yaml
+        - uses: git-commit
+          config:
+            path: ./out
+            message: |
+              kargo: bump gateway-api to ${{ commitFrom("https://github.com/kubernetes-sigs/gateway-api.git").Tag }}
+        - uses: git-push
+          config:
+            path: ./out
+            targetBranch: live
+        - uses: argocd-update
+          config:
+            apps:
+              - name: gateway-api
+                namespace: argocd

--- a/kargo-projects/gateway-api/stage.yaml
+++ b/kargo-projects/gateway-api/stage.yaml
@@ -47,8 +47,3 @@ spec:
           config:
             path: ./out
             targetBranch: live
-        - uses: argocd-update
-          config:
-            apps:
-              - name: gateway-api
-                namespace: argocd

--- a/kargo-projects/gateway-api/warehouse.yaml
+++ b/kargo-projects/gateway-api/warehouse.yaml
@@ -1,0 +1,12 @@
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Warehouse
+metadata:
+  name: gateway-api
+  namespace: kargo-gateway-api
+spec:
+  subscriptions:
+    - git:
+        repoURL: https://github.com/kubernetes-sigs/gateway-api.git
+        commitSelectionStrategy: SemVer
+        allowTagsRegexes:
+          - "^v1\\..*"

--- a/kargo-projects/kustomization.yaml
+++ b/kargo-projects/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - argocd
+  - cert-manager
+  - cert-manager-webhook-linode
+  - gateway-api
+  - traefik

--- a/kargo-projects/traefik/kustomization.yaml
+++ b/kargo-projects/traefik/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - project.yaml
+  - warehouse.yaml
+  - stage.yaml

--- a/kargo-projects/traefik/project.yaml
+++ b/kargo-projects/traefik/project.yaml
@@ -1,0 +1,8 @@
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Project
+metadata:
+  name: kargo-traefik
+spec:
+  promotionPolicies:
+    - stage: main
+      autoPromotionEnabled: true

--- a/kargo-projects/traefik/stage.yaml
+++ b/kargo-projects/traefik/stage.yaml
@@ -51,8 +51,3 @@ spec:
           config:
             path: ./out
             targetBranch: live
-        - uses: argocd-update
-          config:
-            apps:
-              - name: traefik
-                namespace: argocd

--- a/kargo-projects/traefik/stage.yaml
+++ b/kargo-projects/traefik/stage.yaml
@@ -1,0 +1,58 @@
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+metadata:
+  name: main
+  namespace: kargo-traefik
+spec:
+  requestedFreight:
+    - origin:
+        kind: Warehouse
+        name: traefik
+      sources:
+        direct: true
+  promotionTemplate:
+    spec:
+      steps:
+        - uses: git-clone
+          config:
+            repoURL: git@github.com:andyleap-cluster/cluster.git
+            checkout:
+              - branch: master
+                path: ./src
+              - branch: live
+                create: true
+                path: ./out
+        - uses: copy
+          config:
+            inPath: ./src/cluster/traefik.yaml
+            outPath: ./out/cluster/traefik.yaml
+        - uses: copy
+          config:
+            inPath: ./src/traefik
+            outPath: ./out/traefik
+        - uses: yaml-update
+          config:
+            path: ./out/cluster/traefik.yaml
+            updates:
+              - key: spec.sources.0.targetRevision
+                value: ${{ chartFrom("https://traefik.github.io/charts", "traefik").Version }}
+        - uses: yaml-update
+          config:
+            path: ./out/traefik/values.yaml
+            updates:
+              - key: image.tag
+                value: ${{ imageFrom("docker.io/traefik").Tag }}
+        - uses: git-commit
+          config:
+            path: ./out
+            message: |
+              kargo: bump traefik to chart ${{ chartFrom("https://traefik.github.io/charts", "traefik").Version }} / image ${{ imageFrom("docker.io/traefik").Tag }}
+        - uses: git-push
+          config:
+            path: ./out
+            targetBranch: live
+        - uses: argocd-update
+          config:
+            apps:
+              - name: traefik
+                namespace: argocd

--- a/kargo-projects/traefik/warehouse.yaml
+++ b/kargo-projects/traefik/warehouse.yaml
@@ -1,0 +1,15 @@
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Warehouse
+metadata:
+  name: traefik
+  namespace: kargo-traefik
+spec:
+  subscriptions:
+    - chart:
+        repoURL: https://traefik.github.io/charts
+        name: traefik
+        semverConstraint: ">=34.0.0 <35.0.0"
+    - image:
+        repoURL: docker.io/traefik
+        imageSelectionStrategy: SemVer
+        constraint: ">=3.0.0 <4.0.0"

--- a/kargo/values.yaml
+++ b/kargo/values.yaml
@@ -29,6 +29,12 @@ controller:
   argocd:
     integrationEnabled: true
     namespace: argocd
+  # Make Secrets in the `kargo` namespace (created by Terraform) available
+  # to every Kargo project. Otherwise each project's namespace would need
+  # its own copy of the cluster-repo-creds Secret.
+  globalCredentials:
+    namespaces:
+      - kargo
 
 managementController:
   enabled: true


### PR DESCRIPTION
## Summary

Phase 5 of the Kargo rollout. Wires up the actual automation: each of our 5 managed apps gets its own Kargo project with one Warehouse + one Stage. After this PR + apply, Kargo starts polling upstream chart repos / image registries / git tags and writing bumps to the `live` branch.

ArgoCD apps still point at `master` in this PR — Phase 6 flips them. So this is effectively a **shadow run**: Kargo populates `live`, you can review the diff vs `master` to see exactly what would deploy before cutting over.

## Per-app project layout

Each app in [kargo-projects/<app>/](kargo-projects/) has:

- **`project.yaml`** — `Project` named `kargo-<app>` (creates a same-named namespace), with `promotionPolicies` enabling auto-promotion on its single Stage
- **`warehouse.yaml`** — Warehouse subscribing to the relevant upstream sources
- **`stage.yaml`** — Stage named `main`, requesting freight from the Warehouse, with an inline promotionTemplate

| App | Subscribes to | Writes to (on `live`) |
|---|---|---|
| argocd | argo-cd chart `>=8.0.0 <9.0.0` | `cluster/argocd.yaml` targetRevision |
| cert-manager | cert-manager chart `>=1.16.0 <2.0.0` | `cluster/cert-manager.yaml` targetRevision |
| cert-manager-webhook-linode | linode/cert-manager-webhook-linode git tags `^v0\..*` + image `>=0.3.0 <1.0.0` | `cluster/cert-manager-webhook-linode.yaml` targetRevision + `cert-manager-webhook-linode/values.yaml` image.tag |
| gateway-api | kubernetes-sigs/gateway-api git tags `^v1\..*` | `gateway-api/kustomization.yaml` resources[0] URL |
| traefik | traefik chart `>=34.0.0 <35.0.0` + traefik image `>=3.0.0 <4.0.0` | `cluster/traefik.yaml` targetRevision + `traefik/values.yaml` image.tag |

## Promotion shape (each Stage)

```
git-clone (master -> ./src, live -> ./out create=true)
copy ./src/cluster/<app>.yaml -> ./out/cluster/<app>.yaml
copy ./src/<app> -> ./out/<app>
yaml-update (the bumps)
git-commit
git-push to live
```

Each Stage owns its specific files and copies them from master each promotion. Human-authored master changes flow into `live` automatically on the next promotion. Files not owned by any stage (`cluster/cluster.yaml`, `cluster/kargo.yaml`, `cluster/kargo-projects.yaml`) stay as they were on `live` from Phase 2; changing those rare files needs a manual `git merge master` on `live`.

No `argocd-update` step yet — Copilot pointed out it would stall during the shadow run (waits for Apps to reach `live`'s revisions, but Apps are pinned at `master` until Phase 6). After the cutover, ArgoCD's normal auto-sync (~3min poll) picks up Kargo's commits without needing a nudge. We can add `argocd-update` back later if we want faster reaction time.

## Side changes

- [kargo/values.yaml](kargo/values.yaml): added `controller.globalCredentials.namespaces: [kargo]` so the Terraform-managed `cluster-repo-creds` Secret in the `kargo` namespace is available to every Kargo project (otherwise each project's namespace would need its own copy).
- Each `cluster/<app>.yaml` gains a `kargo.akuity.io/authorized-stage` annotation. Not consumed by anything in this PR; left in place so that adding `argocd-update` later doesn't require another round-trip on the App manifests.

## Test plan

After merge:
- [ ] ArgoCD shows `kargo-projects` Application Synced/Healthy
- [ ] `kubectl get projects.kargo.akuity.io` lists all 5
- [ ] `kubectl get warehouses,stages -A -l 'kargo.akuity.io/project'` shows 5 of each across the per-project namespaces
- [ ] Each Warehouse `.status.discoveredArtifacts` populates within ~1 min
- [ ] Each Stage's first Promotion runs through to completion (check `kubectl get promotions -A`)
- [ ] `git log master..live` shows 5 commits — one per Stage — with bumped versions
- [ ] `argocd.andyleap.dev` and friends remain healthy (we haven't cut anyone over to live yet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
