### PR TITLE
Cutover ArgoCD apps to live branch (Phase 6)

### DIFF
--- a/cluster/argocd.yaml
+++ b/cluster/argocd.yaml
@@ -17,10 +17,10 @@ spec:
         valueFiles:
           - $values/argocd/values.yaml
     - repoURL: 'https://github.com/andyleap-cluster/cluster.git'
-      targetRevision: master
+      targetRevision: live
       ref: values
     - repoURL: 'https://github.com/andyleap-cluster/cluster.git'
-      targetRevision: master
+      targetRevision: live
       path: argocd/extras
   destination:
     server: 'https://kubernetes.default.svc'

--- a/cluster/cert-manager-webhook-linode.yaml
+++ b/cluster/cert-manager-webhook-linode.yaml
@@ -17,7 +17,7 @@ spec:
         valueFiles:
           - $values/cert-manager-webhook-linode/values.yaml
     - repoURL: 'https://github.com/andyleap-cluster/cluster.git'
-      targetRevision: master
+      targetRevision: live
       ref: values
   destination:
     server: 'https://kubernetes.default.svc'

--- a/cluster/cert-manager.yaml
+++ b/cluster/cert-manager.yaml
@@ -17,10 +17,10 @@ spec:
         valueFiles:
           - $values/cert-manager/values.yaml
     - repoURL: 'https://github.com/andyleap-cluster/cluster.git'
-      targetRevision: master
+      targetRevision: live
       ref: values
     - repoURL: 'https://github.com/andyleap-cluster/cluster.git'
-      targetRevision: master
+      targetRevision: live
       path: cert-manager/extras
   destination:
     server: 'https://kubernetes.default.svc'

--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -10,7 +10,7 @@ spec:
   source:
     repoURL: 'https://github.com/andyleap-cluster/cluster.git'
     path: cluster
-    targetRevision: master
+    targetRevision: live
   destination:
     server: 'https://kubernetes.default.svc'
     namespace: argocd

--- a/cluster/gateway-api.yaml
+++ b/cluster/gateway-api.yaml
@@ -12,7 +12,7 @@ spec:
   source:
     repoURL: 'https://github.com/andyleap-cluster/cluster.git'
     path: gateway-api
-    targetRevision: master
+    targetRevision: live
   destination:
     server: 'https://kubernetes.default.svc'
     namespace: default

--- a/cluster/traefik.yaml
+++ b/cluster/traefik.yaml
@@ -17,10 +17,10 @@ spec:
         valueFiles:
           - $values/traefik/values.yaml
     - repoURL: 'https://github.com/andyleap-cluster/cluster.git'
-      targetRevision: master
+      targetRevision: live
       ref: values
     - repoURL: 'https://github.com/andyleap-cluster/cluster.git'
-      targetRevision: master
+      targetRevision: live
       path: traefik/extras
   destination:
     server: 'https://kubernetes.default.svc'


### PR DESCRIPTION
## Summary

Phase 6 — the cutover. Flips `targetRevision: master` → `live` on:

- `cluster/cluster.yaml` (so the root scans `cluster/` from `live`)
- The 5 Kargo-managed Apps: argocd, cert-manager, cert-manager-webhook-linode, gateway-api, traefik (their this-repo sources for values + extras + the `cluster/<app>.yaml` files Kargo writes)

After this, Kargo's writes to `live` actually deploy.

## What stays on master

- `cluster/kargo.yaml`: Kargo doesn't manage its own chart yet, so its values come from master (human-authored)
- `cluster/kargo-projects.yaml`: the Project/Warehouse/Stage definitions are human-authored, stay master-sourced

Both files still exist on `live` (from the Phase 2 branch creation), and their content keeps pointing at master for the this-repo sources. So the cluster App reading from `live` still sees and manages them; their inputs just come from master.

## ⚠ Post-merge runbook (must run, else oscillation)

After this PR merges, immediately:

```
git fetch
git push origin master:live --force-with-lease
```

Why: `cluster/cluster.yaml` is self-managing. After merge, ArgoCD reconciles the root App, sees the new content (targetRevision=live), updates its in-cluster spec to scan `live`. Then it reads `cluster/cluster.yaml` from `live` — which (until you run the command above) still says targetRevision=master from Phase 2's branch creation. So it flips back to master. Then it reads cluster.yaml from master again (now says live), flips again. Ping-pong.

The force-push makes `live` identical to `master` (post-merge), so both branches agree the targetRevision is `live`. The cluster App stabilizes.

Any Kargo shadow-run commits on `live` (from the Phase 5 dry-run) get wiped by this. Kargo re-promotes them within a few minutes (the Warehouses still have the freight, Stages still want to promote it).

## Test plan

Immediately after running the force-push:
- [ ] `kubectl get application -n argocd -o jsonpath='{range .items[*]}{.metadata.name}: {.spec.source.targetRevision}{"\n"}{end}'` — all five managed Apps' relevant sources read `live`; `kargo` and `kargo-projects` still read `master`; `cluster` reads `live`
- [ ] All Apps reach `Synced/Healthy` (give it ~5 min — first sync re-applies whatever Kargo bumped on `live`)
- [ ] `git log master..live` after Kargo's first promotions shows fresh commits with the latest discovered versions
- [ ] `argocd.andyleap.dev` still loads, cert-manager still issues, traefik still routes

If anything breaks, revert is straightforward: `git revert <merge-commit>` and `git push origin master:live --force-with-lease` again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
