### PR TITLE
Fix Kargo schemas, controller RBAC, add cluster-repo Warehouse

### DIFF
--- a/kargo-projects/argocd/cluster-repo-warehouse.yaml
+++ b/kargo-projects/argocd/cluster-repo-warehouse.yaml
@@ -1,0 +1,15 @@
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Warehouse
+metadata:
+  name: cluster-repo
+  namespace: kargo-argocd
+spec:
+  subscriptions:
+    # Triggers a promotion when the human-authored master branch advances,
+    # so master changes get copied into live without waiting on an upstream
+    # chart/image bump.
+    - git:
+        repoURL: https://github.com/andyleap-cluster/cluster.git
+        branch: master
+        commitSelectionStrategy: NewestFromBranch
+        strictSemvers: false

--- a/kargo-projects/argocd/kustomization.yaml
+++ b/kargo-projects/argocd/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
 resources:
-  - project.yaml
-  - warehouse.yaml
-  - stage.yaml
+- project.yaml
+- warehouse.yaml
+- cluster-repo-warehouse.yaml
+- stage.yaml

--- a/kargo-projects/argocd/stage.yaml
+++ b/kargo-projects/argocd/stage.yaml
@@ -10,6 +10,11 @@ spec:
         name: argocd
       sources:
         direct: true
+    - origin:
+        kind: Warehouse
+        name: cluster-repo
+      sources:
+        direct: true
   promotionTemplate:
     spec:
       steps:

--- a/kargo-projects/cert-manager-webhook-linode/cluster-repo-warehouse.yaml
+++ b/kargo-projects/cert-manager-webhook-linode/cluster-repo-warehouse.yaml
@@ -1,0 +1,15 @@
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Warehouse
+metadata:
+  name: cluster-repo
+  namespace: kargo-cert-manager-webhook-linode
+spec:
+  subscriptions:
+    # Triggers a promotion when the human-authored master branch advances,
+    # so master changes get copied into live without waiting on an upstream
+    # chart/image bump.
+    - git:
+        repoURL: https://github.com/andyleap-cluster/cluster.git
+        branch: master
+        commitSelectionStrategy: NewestFromBranch
+        strictSemvers: false

--- a/kargo-projects/cert-manager-webhook-linode/kustomization.yaml
+++ b/kargo-projects/cert-manager-webhook-linode/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
 resources:
-  - project.yaml
-  - warehouse.yaml
-  - stage.yaml
+- project.yaml
+- warehouse.yaml
+- cluster-repo-warehouse.yaml
+- stage.yaml

--- a/kargo-projects/cert-manager-webhook-linode/stage.yaml
+++ b/kargo-projects/cert-manager-webhook-linode/stage.yaml
@@ -10,6 +10,11 @@ spec:
         name: cert-manager-webhook-linode
       sources:
         direct: true
+    - origin:
+        kind: Warehouse
+        name: cluster-repo
+      sources:
+        direct: true
   promotionTemplate:
     spec:
       steps:

--- a/kargo-projects/cert-manager-webhook-linode/warehouse.yaml
+++ b/kargo-projects/cert-manager-webhook-linode/warehouse.yaml
@@ -10,9 +10,10 @@ spec:
     - git:
         repoURL: https://github.com/linode/cert-manager-webhook-linode.git
         commitSelectionStrategy: SemVer
-        allowTagsRegexes:
-          - "^v0\\..*"
+        semverConstraint: ">=0.3.0 <1.0.0"
+        strictSemvers: true
     - image:
         repoURL: docker.io/linode/cert-manager-webhook-linode
         imageSelectionStrategy: SemVer
-        constraint: ">=0.3.0 <1.0.0"
+        semverConstraint: ">=0.3.0 <1.0.0"
+        strictSemvers: true

--- a/kargo-projects/cert-manager/cluster-repo-warehouse.yaml
+++ b/kargo-projects/cert-manager/cluster-repo-warehouse.yaml
@@ -1,0 +1,15 @@
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Warehouse
+metadata:
+  name: cluster-repo
+  namespace: kargo-cert-manager
+spec:
+  subscriptions:
+    # Triggers a promotion when the human-authored master branch advances,
+    # so master changes get copied into live without waiting on an upstream
+    # chart/image bump.
+    - git:
+        repoURL: https://github.com/andyleap-cluster/cluster.git
+        branch: master
+        commitSelectionStrategy: NewestFromBranch
+        strictSemvers: false

--- a/kargo-projects/cert-manager/kustomization.yaml
+++ b/kargo-projects/cert-manager/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
 resources:
-  - project.yaml
-  - warehouse.yaml
-  - stage.yaml
+- project.yaml
+- warehouse.yaml
+- cluster-repo-warehouse.yaml
+- stage.yaml

--- a/kargo-projects/cert-manager/stage.yaml
+++ b/kargo-projects/cert-manager/stage.yaml
@@ -10,6 +10,11 @@ spec:
         name: cert-manager
       sources:
         direct: true
+    - origin:
+        kind: Warehouse
+        name: cluster-repo
+      sources:
+        direct: true
   promotionTemplate:
     spec:
       steps:

--- a/kargo-projects/gateway-api/cluster-repo-warehouse.yaml
+++ b/kargo-projects/gateway-api/cluster-repo-warehouse.yaml
@@ -1,0 +1,15 @@
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Warehouse
+metadata:
+  name: cluster-repo
+  namespace: kargo-gateway-api
+spec:
+  subscriptions:
+    # Triggers a promotion when the human-authored master branch advances,
+    # so master changes get copied into live without waiting on an upstream
+    # chart/image bump.
+    - git:
+        repoURL: https://github.com/andyleap-cluster/cluster.git
+        branch: master
+        commitSelectionStrategy: NewestFromBranch
+        strictSemvers: false

--- a/kargo-projects/gateway-api/kustomization.yaml
+++ b/kargo-projects/gateway-api/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
 resources:
-  - project.yaml
-  - warehouse.yaml
-  - stage.yaml
+- project.yaml
+- warehouse.yaml
+- cluster-repo-warehouse.yaml
+- stage.yaml

--- a/kargo-projects/gateway-api/stage.yaml
+++ b/kargo-projects/gateway-api/stage.yaml
@@ -10,6 +10,11 @@ spec:
         name: gateway-api
       sources:
         direct: true
+    - origin:
+        kind: Warehouse
+        name: cluster-repo
+      sources:
+        direct: true
   promotionTemplate:
     spec:
       steps:

--- a/kargo-projects/gateway-api/warehouse.yaml
+++ b/kargo-projects/gateway-api/warehouse.yaml
@@ -8,5 +8,5 @@ spec:
     - git:
         repoURL: https://github.com/kubernetes-sigs/gateway-api.git
         commitSelectionStrategy: SemVer
-        allowTagsRegexes:
-          - "^v1\\..*"
+        semverConstraint: ">=1.0.0 <2.0.0"
+        strictSemvers: true

--- a/kargo-projects/traefik/cluster-repo-warehouse.yaml
+++ b/kargo-projects/traefik/cluster-repo-warehouse.yaml
@@ -1,0 +1,15 @@
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Warehouse
+metadata:
+  name: cluster-repo
+  namespace: kargo-traefik
+spec:
+  subscriptions:
+    # Triggers a promotion when the human-authored master branch advances,
+    # so master changes get copied into live without waiting on an upstream
+    # chart/image bump.
+    - git:
+        repoURL: https://github.com/andyleap-cluster/cluster.git
+        branch: master
+        commitSelectionStrategy: NewestFromBranch
+        strictSemvers: false

--- a/kargo-projects/traefik/kustomization.yaml
+++ b/kargo-projects/traefik/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
 resources:
-  - project.yaml
-  - warehouse.yaml
-  - stage.yaml
+- project.yaml
+- warehouse.yaml
+- cluster-repo-warehouse.yaml
+- stage.yaml

--- a/kargo-projects/traefik/stage.yaml
+++ b/kargo-projects/traefik/stage.yaml
@@ -10,6 +10,11 @@ spec:
         name: traefik
       sources:
         direct: true
+    - origin:
+        kind: Warehouse
+        name: cluster-repo
+      sources:
+        direct: true
   promotionTemplate:
     spec:
       steps:

--- a/kargo-projects/traefik/warehouse.yaml
+++ b/kargo-projects/traefik/warehouse.yaml
@@ -12,4 +12,5 @@ spec:
     - image:
         repoURL: docker.io/traefik
         imageSelectionStrategy: SemVer
-        constraint: ">=3.0.0 <4.0.0"
+        semverConstraint: ">=3.0.0 <4.0.0"
+        strictSemvers: true

--- a/kargo/extras/global-credentials-rbac.yaml
+++ b/kargo/extras/global-credentials-rbac.yaml
@@ -1,0 +1,26 @@
+# Grants the kargo-controller ServiceAccount permission to read Secrets in the
+# kargo namespace. Required because controller.globalCredentials.namespaces in
+# the chart only sets an env var — it doesn't auto-create the RoleBinding.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kargo-controller-global-credentials-reader
+  namespace: kargo
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kargo-controller-global-credentials-reader
+  namespace: kargo
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kargo-controller-global-credentials-reader
+subjects:
+  - kind: ServiceAccount
+    name: kargo-controller
+    namespace: kargo

--- a/kargo/extras/kustomization.yaml
+++ b/kargo/extras/kustomization.yaml
@@ -4,4 +4,5 @@ kind: Kustomization
 namespace: kargo
 
 resources:
+  - global-credentials-rbac.yaml
   - httproute.yaml


### PR DESCRIPTION
## Summary

Three bugs surfaced after Phase 5 (#44) deployed.

### 1. Warehouse schema mismatch

Three of the five Warehouses failed to apply with `field not declared in schema`. The installed Kargo CRD's git/image subscription schemas don't have the field names the docs example used:

| Was | Now |
|---|---|
| `git.allowTagsRegexes: [...]` | dropped (semverConstraint covers it) |
| `git` without `strictSemvers` | `strictSemvers: true` (required field) |
| `image.constraint: "..."` | `semverConstraint: "..."` |
| `image` without `strictSemvers` | `strictSemvers: true` (required) |

Switched the version filter to `commitSelectionStrategy: SemVer` + `semverConstraint` for cleaner expression and dropped the redundant tag regex.

### 2. Controller RBAC for globalCredentials

`controller.globalCredentials.namespaces: [kargo]` in [kargo/values.yaml](kargo/values.yaml) only sets the `GLOBAL_CREDENTIALS_NAMESPACES` env var on the controller — the chart does **not** auto-create the RoleBinding. The controller was failing every credential lookup with `secrets is forbidden ... in namespace "kargo"`.

Added [kargo/extras/global-credentials-rbac.yaml](kargo/extras/global-credentials-rbac.yaml) granting the `kargo-controller` SA `get`/`list`/`watch` on Secrets in the `kargo` namespace.

### 3. Per-project cluster-repo Warehouse

Without this, Stages only re-promoted when an upstream chart/image/git warehouse produced new freight. Human-authored master changes (e.g. config tweaks, new Helm values) sat on master until the next upstream-driven promotion happened to fire.

Each project now has a second Warehouse, `cluster-repo`, tracking master via `commitSelectionStrategy: NewestFromBranch`. Each Stage's `requestedFreight` references both its app-specific warehouse and `cluster-repo`. Any push to master now triggers a promotion that copies the new master content into live.

## Test plan

After merge:
- [ ] All 10 Warehouses across the 5 namespaces show `Ready: True`
- [ ] Each Warehouse `.status.discoveredArtifacts` populates within ~1 min
- [ ] Each Stage's first Promotion runs end-to-end (`kubectl get promotions -A`)
- [ ] Push a no-op commit to master and confirm a fresh Promotion fires within ~1 min via the cluster-repo Warehouse

🤖 Generated with [Claude Code](https://claude.com/claude-code)