### PR TITLE
Revert cutover: point ArgoCD apps back at master

### DIFF
--- a/cluster/argocd.yaml
+++ b/cluster/argocd.yaml
@@ -17,10 +17,10 @@ spec:
         valueFiles:
           - $values/argocd/values.yaml
     - repoURL: 'https://github.com/andyleap-cluster/cluster.git'
-      targetRevision: live
+      targetRevision: master
       ref: values
     - repoURL: 'https://github.com/andyleap-cluster/cluster.git'
-      targetRevision: live
+      targetRevision: master
       path: argocd/extras
   destination:
     server: 'https://kubernetes.default.svc'

--- a/cluster/cert-manager-webhook-linode.yaml
+++ b/cluster/cert-manager-webhook-linode.yaml
@@ -17,7 +17,7 @@ spec:
         valueFiles:
           - $values/cert-manager-webhook-linode/values.yaml
     - repoURL: 'https://github.com/andyleap-cluster/cluster.git'
-      targetRevision: live
+      targetRevision: master
       ref: values
   destination:
     server: 'https://kubernetes.default.svc'

--- a/cluster/cert-manager.yaml
+++ b/cluster/cert-manager.yaml
@@ -17,10 +17,10 @@ spec:
         valueFiles:
           - $values/cert-manager/values.yaml
     - repoURL: 'https://github.com/andyleap-cluster/cluster.git'
-      targetRevision: live
+      targetRevision: master
       ref: values
     - repoURL: 'https://github.com/andyleap-cluster/cluster.git'
-      targetRevision: live
+      targetRevision: master
       path: cert-manager/extras
   destination:
     server: 'https://kubernetes.default.svc'

--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -10,7 +10,7 @@ spec:
   source:
     repoURL: 'https://github.com/andyleap-cluster/cluster.git'
     path: cluster
-    targetRevision: live
+    targetRevision: master
   destination:
     server: 'https://kubernetes.default.svc'
     namespace: argocd

--- a/cluster/gateway-api.yaml
+++ b/cluster/gateway-api.yaml
@@ -12,7 +12,7 @@ spec:
   source:
     repoURL: 'https://github.com/andyleap-cluster/cluster.git'
     path: gateway-api
-    targetRevision: live
+    targetRevision: master
   destination:
     server: 'https://kubernetes.default.svc'
     namespace: default

--- a/cluster/traefik.yaml
+++ b/cluster/traefik.yaml
@@ -17,10 +17,10 @@ spec:
         valueFiles:
           - $values/traefik/values.yaml
     - repoURL: 'https://github.com/andyleap-cluster/cluster.git'
-      targetRevision: live
+      targetRevision: master
       ref: values
     - repoURL: 'https://github.com/andyleap-cluster/cluster.git'
-      targetRevision: live
+      targetRevision: master
       path: traefik/extras
   destination:
     server: 'https://kubernetes.default.svc'


### PR DESCRIPTION
## Summary

Reverts the targetRevision flips from Phase 6 (#45). All cluster/<app>.yaml this-repo sources and cluster/cluster.yaml itself go back to `master`. Keeps the cluster healthy while we redo the live-branch experiment from a clean (empty) baseline.

Why: live had drifted 14 commits behind master (the post-merge force-push runbook from #45 wasn't run at merge time). Apps reading values/extras from live were getting pre-#35 content (no `<app>/extras/` directories), breaking renders.

## After merge — wipe live and restart as empty orphan branch

```
git push origin --delete live
git checkout --orphan live
git rm -rf .
git commit --allow-empty -m "live: empty orphan branch for Kargo promotions"
git push -u origin live
```

Live ends up with no files. Kargo's Stage promotions will incrementally populate it as upstream warehouses produce freight — each Stage copies its owned slice from master + applies its bumps, ending up on live.

ArgoCD root keeps reading cluster/ from master, so live's content has no deploy effect yet. When we re-cut Phase 6 (this time atomically with the runbook), the targetRevisions flip and live's accumulated content goes live.

## Test plan

- [ ] After merge, all 8 ArgoCD Apps reconcile Synced/Healthy on master content
- [ ] `kubectl get application cluster -n argocd -o jsonpath='{.spec.source.targetRevision}'` returns `master`
- [ ] Run the wipe-and-recreate runbook above; verify `git log origin/live` shows only the new empty-orphan commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)
