### PR TITLE
Serialize Kargo promotions to avoid git-push races

### DIFF
--- a/kargo/values.yaml
+++ b/kargo/values.yaml
@@ -35,6 +35,13 @@ controller:
   globalCredentials:
     namespaces:
       - kargo
+  # Serialize promotions cluster-wide. All Stages push to the same live
+  # branch, so concurrent promotions race and 3-of-4 lose on non-fast-forward.
+  # The default git-push retry just re-pushes the same commit so it doesn't
+  # rebase on conflict. One worker = no race.
+  reconcilers:
+    promotions:
+      maxConcurrentReconciles: 1
 
 managementController:
   enabled: true


### PR DESCRIPTION
## Summary

All 5 Stages push to the same `live` branch. With the default `controller.reconcilers.promotions.maxConcurrentReconciles` of 4, when multiple Stages have pending freight (common after a master push, since every Warehouse subscribes to master) they race on `git push` and 3-of-4 lose with non-fast-forward.

`git-push`'s built-in retry (`maxAttempts` default 10) just re-pushes the same commit on each retry — it doesn't rebase, so retries fail the same way and the promotion surfaces as `Errored`. The user observed this in cluster state.

## Fix

Cap the promotions reconciler to 1 concurrent worker. Promotions serialize cluster-wide. Throughput cost is negligible at this scale (5 stages, sub-second per promotion).

Rendered env on the controller pod after this change:
```
MAX_CONCURRENT_PROMOTION_RECONCILES: "1"
```
Other reconcilers (stages, warehouses, control-flow) stay at the chart default of 4.

## Test plan

- [ ] After merge + chart resync, controller env `MAX_CONCURRENT_PROMOTION_RECONCILES` shows `1`
- [ ] Push a no-op commit to master; observe all 5 Stages get fresh freight and their promotions complete in series with no `non-fast-forward` errors

## Future ideas if this becomes a throughput problem

- Per-stage branches with an aggregator, e.g. `live-argocd` → merged into `live` by a separate workflow
- Replace `git-push` with a step that fetches + rebases before push

🤖 Generated with [Claude Code](https://claude.com/claude-code)