### PR TITLE
Add kargo-kargo project: Kargo manages itself + unowned manifests

### DIFF
--- a/kargo-projects/kargo/kustomization.yaml
+++ b/kargo-projects/kargo/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - project.yaml
+  - warehouse.yaml
+  - stage.yaml

--- a/kargo-projects/kargo/project.yaml
+++ b/kargo-projects/kargo/project.yaml
@@ -1,0 +1,8 @@
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Project
+metadata:
+  name: kargo-kargo
+spec:
+  promotionPolicies:
+    - stage: main
+      autoPromotionEnabled: true

--- a/kargo-projects/kargo/stage.yaml
+++ b/kargo-projects/kargo/stage.yaml
@@ -1,0 +1,65 @@
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+metadata:
+  name: main
+  namespace: kargo-kargo
+spec:
+  requestedFreight:
+    - origin:
+        kind: Warehouse
+        name: kargo
+      sources:
+        direct: true
+  promotionTemplate:
+    spec:
+      steps:
+        - uses: git-clone
+          config:
+            repoURL: git@github.com:andyleap-cluster/cluster.git
+            checkout:
+              - branch: master
+                path: ./src
+              - branch: live
+                create: true
+                path: ./out
+        # Clear the kargo helm values directory so removed files on master
+        # don't linger on live.
+        - uses: git-clear
+          config:
+            path: ./out/kargo
+        - uses: copy
+          config:
+            inPath: ./src/kargo
+            outPath: ./out/kargo
+        # Three single-file copies for unowned ArgoCD Application manifests.
+        # Putting them in this Stage's slice prevents the root cluster App
+        # from pruning the kargo/kargo-projects/cluster Apps after cutover.
+        - uses: copy
+          config:
+            inPath: ./src/cluster/kargo.yaml
+            outPath: ./out/cluster/kargo.yaml
+        - uses: copy
+          config:
+            inPath: ./src/cluster/kargo-projects.yaml
+            outPath: ./out/cluster/kargo-projects.yaml
+        - uses: copy
+          config:
+            inPath: ./src/cluster/cluster.yaml
+            outPath: ./out/cluster/cluster.yaml
+        # Bump the kargo chart targetRevision to whatever the warehouse
+        # discovered.
+        - uses: yaml-update
+          config:
+            path: ./out/cluster/kargo.yaml
+            updates:
+              - key: spec.sources.0.targetRevision
+                value: ${{ chartFrom("oci://ghcr.io/akuity/kargo-charts/kargo").Version }}
+        - uses: git-commit
+          config:
+            path: ./out
+            message: |
+              kargo: bump kargo to chart ${{ chartFrom("oci://ghcr.io/akuity/kargo-charts/kargo").Version }}
+        - uses: git-push
+          config:
+            path: ./out
+            targetBranch: live

--- a/kargo-projects/kargo/warehouse.yaml
+++ b/kargo-projects/kargo/warehouse.yaml
@@ -1,0 +1,15 @@
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Warehouse
+metadata:
+  name: kargo
+  namespace: kargo-kargo
+spec:
+  subscriptions:
+    - chart:
+        repoURL: oci://ghcr.io/akuity/kargo-charts/kargo
+        semverConstraint: ">=1.0.0 <2.0.0"
+    - git:
+        repoURL: https://github.com/andyleap-cluster/cluster.git
+        branch: master
+        commitSelectionStrategy: NewestFromBranch
+        strictSemvers: false

--- a/kargo-projects/kustomization.yaml
+++ b/kargo-projects/kustomization.yaml
@@ -6,4 +6,5 @@ resources:
   - cert-manager
   - cert-manager-webhook-linode
   - gateway-api
+  - kargo
   - traefik


### PR DESCRIPTION
## Summary

New per-app project, `kargo-kargo`, whose Stage owns the four files that no other Stage covers:

| File | Why it's here |
|---|---|
| `cluster/kargo.yaml` | Kargo's own Application manifest. Stage bumps its chart targetRevision. |
| `cluster/kargo-projects.yaml` | Carrier for the Kargo project defs. Stage copies as-is. |
| `cluster/cluster.yaml` | Root self-managing Application. Stage copies as-is. |
| `kargo/` | Kargo helm values + extras (RBAC, HTTPRoute). Stage copies as-is. |

Without this Stage, after Phase 6 cutover (cluster App scans `cluster/` from `live`), ArgoCD wouldn't find `cluster/kargo.yaml` or `cluster/kargo-projects.yaml` on `live` and would prune the kargo + kargo-projects Apps. This Stage's job is to put them on `live`.

Warehouse subscribes to:
- `oci://ghcr.io/akuity/kargo-charts/kargo` (semver `>=1.0.0 <2.0.0`)
- cluster repo master branch

Same single-warehouse-per-pipeline pattern as #48.

## Test plan

- [ ] After merge, `kubectl -n kargo-kargo get warehouse,stage` lists both, Ready
- [ ] Within ~1 min the Stage runs its first promotion and `git log master..live` shows a new commit from `kargo-kargo`
- [ ] `git show origin/live -- cluster/kargo.yaml cluster/kargo-projects.yaml cluster/cluster.yaml kargo/` shows those files now exist on live

## Follow-up PRs

- PR adding `git-clear` to all 6 Stages so removed-from-master files don't linger on live
- PR redoing Phase 6 cutover (`targetRevision: master` → `live` on cluster/*.yaml). Safe to merge only after this PR's Stage has populated live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)