### PR TITLE
Clear each Stage's slice before copying from master

### DIFF
--- a/kargo-projects/argocd/stage.yaml
+++ b/kargo-projects/argocd/stage.yaml
@@ -23,6 +23,11 @@ spec:
                 create: true
                 path: ./out
         # Sync this stage's owned slice from master to live, then apply the bump on top.
+        # Clear this stage's dir on live first so files removed from master
+        # don't linger.
+        - uses: git-clear
+          config:
+            path: ./out/argocd
         - uses: copy
           config:
             inPath: ./src/cluster/argocd.yaml

--- a/kargo-projects/cert-manager-webhook-linode/stage.yaml
+++ b/kargo-projects/cert-manager-webhook-linode/stage.yaml
@@ -22,6 +22,9 @@ spec:
               - branch: live
                 create: true
                 path: ./out
+        - uses: git-clear
+          config:
+            path: ./out/cert-manager-webhook-linode
         - uses: copy
           config:
             inPath: ./src/cluster/cert-manager-webhook-linode.yaml

--- a/kargo-projects/cert-manager/stage.yaml
+++ b/kargo-projects/cert-manager/stage.yaml
@@ -22,6 +22,9 @@ spec:
               - branch: live
                 create: true
                 path: ./out
+        - uses: git-clear
+          config:
+            path: ./out/cert-manager
         - uses: copy
           config:
             inPath: ./src/cluster/cert-manager.yaml

--- a/kargo-projects/gateway-api/stage.yaml
+++ b/kargo-projects/gateway-api/stage.yaml
@@ -22,6 +22,9 @@ spec:
               - branch: live
                 create: true
                 path: ./out
+        - uses: git-clear
+          config:
+            path: ./out/gateway-api
         - uses: copy
           config:
             inPath: ./src/cluster/gateway-api.yaml

--- a/kargo-projects/traefik/stage.yaml
+++ b/kargo-projects/traefik/stage.yaml
@@ -22,6 +22,9 @@ spec:
               - branch: live
                 create: true
                 path: ./out
+        - uses: git-clear
+          config:
+            path: ./out/traefik
         - uses: copy
           config:
             inPath: ./src/cluster/traefik.yaml


### PR DESCRIPTION
## Summary

Adds a `git-clear` step before each Stage's directory copy, scoped to that Stage's owned subdirectory.

### Why

Currently a Stage's promotion does `copy ./src/<app>/ → ./out/<app>/`. The `copy` step preserves files at the destination that are no longer in the source — so when a file is deleted from a Stage's owned directory on master (e.g. `argocd/extras/foo.yaml` removed), the next promotion leaves the stale file on live.

`git-clear ./out/<app>` removes everything in that path (preserves `.git`), so the subsequent copy reconstitutes the directory exactly from master.

### Why scoped, not on `./out`

`git-clear ./out` would wipe everything every promotion, including other Stages' slices. Per-Stage scoping means each Stage only touches its own.

Affects:
- kargo-projects/argocd/stage.yaml
- kargo-projects/cert-manager/stage.yaml
- kargo-projects/cert-manager-webhook-linode/stage.yaml
- kargo-projects/gateway-api/stage.yaml
- kargo-projects/traefik/stage.yaml

kargo-projects/kargo/stage.yaml already has the equivalent step (added in #50).

## Test plan

- [ ] After merge + next promotion, `git log master..live` shows a fresh commit per Stage and the diff on live matches master content cleanly
- [ ] Delete a file from any Stage's owned dir on master, push, wait for promotion — file should be gone on live after the next bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)