### PR TITLE
Make git-clear tolerant of missing dirs (first-promotion bootstrap)

### DIFF
--- a/kargo-projects/argocd/stage.yaml
+++ b/kargo-projects/argocd/stage.yaml
@@ -26,6 +26,9 @@ spec:
         # Clear this stage's dir on live first so files removed from master
         # don't linger.
         - uses: git-clear
+          # First promotion against a fresh live has no ./out/argocd — that's
+          # expected; ignore the resulting "no such file or directory" error.
+          continueOnError: true
           config:
             path: ./out/argocd
         - uses: copy

--- a/kargo-projects/cert-manager-webhook-linode/stage.yaml
+++ b/kargo-projects/cert-manager-webhook-linode/stage.yaml
@@ -23,6 +23,9 @@ spec:
                 create: true
                 path: ./out
         - uses: git-clear
+          # First promotion against a fresh live has no ./out/cert-manager-webhook-linode — that's
+          # expected; ignore the resulting "no such file or directory" error.
+          continueOnError: true
           config:
             path: ./out/cert-manager-webhook-linode
         - uses: copy

--- a/kargo-projects/cert-manager/stage.yaml
+++ b/kargo-projects/cert-manager/stage.yaml
@@ -23,6 +23,9 @@ spec:
                 create: true
                 path: ./out
         - uses: git-clear
+          # First promotion against a fresh live has no ./out/cert-manager — that's
+          # expected; ignore the resulting "no such file or directory" error.
+          continueOnError: true
           config:
             path: ./out/cert-manager
         - uses: copy

--- a/kargo-projects/gateway-api/stage.yaml
+++ b/kargo-projects/gateway-api/stage.yaml
@@ -23,6 +23,9 @@ spec:
                 create: true
                 path: ./out
         - uses: git-clear
+          # First promotion against a fresh live has no ./out/gateway-api — that's
+          # expected; ignore the resulting "no such file or directory" error.
+          continueOnError: true
           config:
             path: ./out/gateway-api
         - uses: copy

--- a/kargo-projects/kargo/stage.yaml
+++ b/kargo-projects/kargo/stage.yaml
@@ -25,6 +25,9 @@ spec:
         # Clear the kargo helm values directory so removed files on master
         # don't linger on live.
         - uses: git-clear
+          # First promotion against a fresh live has no ./out/kargo — that's
+          # expected; ignore the resulting "no such file or directory" error.
+          continueOnError: true
           config:
             path: ./out/kargo
         - uses: copy

--- a/kargo-projects/traefik/stage.yaml
+++ b/kargo-projects/traefik/stage.yaml
@@ -23,6 +23,9 @@ spec:
                 create: true
                 path: ./out
         - uses: git-clear
+          # First promotion against a fresh live has no ./out/traefik — that's
+          # expected; ignore the resulting "no such file or directory" error.
+          continueOnError: true
           config:
             path: ./out/traefik
         - uses: copy


### PR DESCRIPTION
## Summary

`git-clear` errors out if its target path doesn't exist:
```
error reading repo dir from config: ... chdir /tmp/promotion-.../out/kargo: no such file or directory
```

This is what's been blocking the new `kargo-kargo` Stage — its first promotion fails at the git-clear step because live has never had a `kargo/` directory. Pure bootstrap problem; subsequent promotions would work fine because the copy step creates the dir.

## Fix

Set `continueOnError: true` on every Stage's git-clear step. The step still runs (and succeeds normally when the dir exists), but a missing-dir error doesn't fail the promotion. The subsequent `copy` step creates the directory; from the second promotion onward git-clear works as intended.

Applied to all 6 Stages so any future fresh-orphan rebuild of `live` works without manual bootstrap commits.

## Test plan

- [ ] After merge, kargo-kargo Stage's next promotion runs end-to-end (no more "no such file or directory" on git-clear)
- [ ] `git log master..live` shows a fresh "kargo: bump kargo to chart 1.x.x" commit
- [ ] `git show origin/live -- cluster/kargo.yaml cluster/kargo-projects.yaml cluster/cluster.yaml kargo/` now lists files

🤖 Generated with [Claude Code](https://claude.com/claude-code)