### PR TITLE
Bump Kargo chart 1.1.1 → 1.10.4

### DIFF
--- a/cluster/kargo.yaml
+++ b/cluster/kargo.yaml
@@ -10,7 +10,7 @@ spec:
   sources:
     - repoURL: 'ghcr.io/akuity/kargo-charts'
       chart: kargo
-      targetRevision: 1.1.1
+      targetRevision: 1.10.4
       helm:
         valueFiles:
           - $values/kargo/values.yaml


### PR DESCRIPTION
## Summary

Brings in the newer Stage CRD that recognizes `continueOnError` (added in #52 but rejected by 1.1.1's CRD with "field not declared in schema"). After this merges and ArgoCD applies the upgraded chart, kargo-projects can sync the continueOnError additions and the kargo-kargo Stage's git-clear will no-op gracefully on the missing-dir bootstrap.

## Breaking-change review (1.1.1 → 1.10.4)

- **Active breaking change**: `freightMetadata`'s deprecated second argument removed in v1.10.0. We don't use it anywhere.
- No CRD-shape changes for Project / Warehouse / Stage / Promotion reconciliation.
- Future deprecations to track:
  - SSH git credentials removed in v1.13.0 (we use SSH for `cluster-repo-creds`)
  - `git-push` default policy changes to `RebaseOrMerge` in v1.12.0

## Test plan

- [ ] After merge, kargo App reaches Synced/Healthy on chart 1.10.4
- [ ] `kubectl get pods -n kargo` all Running on v1.10.4 images
- [ ] kargo-projects App finally syncs cleanly (no more "continueOnError: field not declared in schema")
- [ ] kargo-kargo Stage's next promotion completes; live picks up cluster/kargo.yaml + cluster/kargo-projects.yaml + cluster/cluster.yaml + kargo/

🤖 Generated with [Claude Code](https://claude.com/claude-code)