### PR TITLE
Migrate to Kargo 1.10 schema: ProjectConfig CRD

### DIFF
--- a/kargo-projects/argocd/kustomization.yaml
+++ b/kargo-projects/argocd/kustomization.yaml
@@ -2,5 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - project.yaml
+- projectconfig.yaml
 - warehouse.yaml
 - stage.yaml

--- a/kargo-projects/argocd/project.yaml
+++ b/kargo-projects/argocd/project.yaml
@@ -2,7 +2,3 @@ apiVersion: kargo.akuity.io/v1alpha1
 kind: Project
 metadata:
   name: kargo-argocd
-spec:
-  promotionPolicies:
-    - stage: main
-      autoPromotionEnabled: true

--- a/kargo-projects/argocd/projectconfig.yaml
+++ b/kargo-projects/argocd/projectconfig.yaml
@@ -1,0 +1,9 @@
+apiVersion: kargo.akuity.io/v1alpha1
+kind: ProjectConfig
+metadata:
+  name: kargo-argocd
+  namespace: kargo-argocd
+spec:
+  promotionPolicies:
+    - stage: main
+      autoPromotionEnabled: true

--- a/kargo-projects/cert-manager-webhook-linode/kustomization.yaml
+++ b/kargo-projects/cert-manager-webhook-linode/kustomization.yaml
@@ -2,5 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - project.yaml
+- projectconfig.yaml
 - warehouse.yaml
 - stage.yaml

--- a/kargo-projects/cert-manager-webhook-linode/project.yaml
+++ b/kargo-projects/cert-manager-webhook-linode/project.yaml
@@ -2,7 +2,3 @@ apiVersion: kargo.akuity.io/v1alpha1
 kind: Project
 metadata:
   name: kargo-cert-manager-webhook-linode
-spec:
-  promotionPolicies:
-    - stage: main
-      autoPromotionEnabled: true

--- a/kargo-projects/cert-manager-webhook-linode/projectconfig.yaml
+++ b/kargo-projects/cert-manager-webhook-linode/projectconfig.yaml
@@ -1,0 +1,9 @@
+apiVersion: kargo.akuity.io/v1alpha1
+kind: ProjectConfig
+metadata:
+  name: kargo-cert-manager-webhook-linode
+  namespace: kargo-cert-manager-webhook-linode
+spec:
+  promotionPolicies:
+    - stage: main
+      autoPromotionEnabled: true

--- a/kargo-projects/cert-manager/kustomization.yaml
+++ b/kargo-projects/cert-manager/kustomization.yaml
@@ -2,5 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - project.yaml
+- projectconfig.yaml
 - warehouse.yaml
 - stage.yaml

--- a/kargo-projects/cert-manager/project.yaml
+++ b/kargo-projects/cert-manager/project.yaml
@@ -2,7 +2,3 @@ apiVersion: kargo.akuity.io/v1alpha1
 kind: Project
 metadata:
   name: kargo-cert-manager
-spec:
-  promotionPolicies:
-    - stage: main
-      autoPromotionEnabled: true

--- a/kargo-projects/cert-manager/projectconfig.yaml
+++ b/kargo-projects/cert-manager/projectconfig.yaml
@@ -1,0 +1,9 @@
+apiVersion: kargo.akuity.io/v1alpha1
+kind: ProjectConfig
+metadata:
+  name: kargo-cert-manager
+  namespace: kargo-cert-manager
+spec:
+  promotionPolicies:
+    - stage: main
+      autoPromotionEnabled: true

--- a/kargo-projects/gateway-api/kustomization.yaml
+++ b/kargo-projects/gateway-api/kustomization.yaml
@@ -2,5 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - project.yaml
+- projectconfig.yaml
 - warehouse.yaml
 - stage.yaml

--- a/kargo-projects/gateway-api/project.yaml
+++ b/kargo-projects/gateway-api/project.yaml
@@ -2,7 +2,3 @@ apiVersion: kargo.akuity.io/v1alpha1
 kind: Project
 metadata:
   name: kargo-gateway-api
-spec:
-  promotionPolicies:
-    - stage: main
-      autoPromotionEnabled: true

--- a/kargo-projects/gateway-api/projectconfig.yaml
+++ b/kargo-projects/gateway-api/projectconfig.yaml
@@ -1,0 +1,9 @@
+apiVersion: kargo.akuity.io/v1alpha1
+kind: ProjectConfig
+metadata:
+  name: kargo-gateway-api
+  namespace: kargo-gateway-api
+spec:
+  promotionPolicies:
+    - stage: main
+      autoPromotionEnabled: true

--- a/kargo-projects/kargo/kustomization.yaml
+++ b/kargo-projects/kargo/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
 resources:
-  - project.yaml
-  - warehouse.yaml
-  - stage.yaml
+- project.yaml
+- projectconfig.yaml
+- warehouse.yaml
+- stage.yaml

--- a/kargo-projects/kargo/project.yaml
+++ b/kargo-projects/kargo/project.yaml
@@ -2,7 +2,3 @@ apiVersion: kargo.akuity.io/v1alpha1
 kind: Project
 metadata:
   name: kargo-kargo
-spec:
-  promotionPolicies:
-    - stage: main
-      autoPromotionEnabled: true

--- a/kargo-projects/kargo/projectconfig.yaml
+++ b/kargo-projects/kargo/projectconfig.yaml
@@ -1,0 +1,9 @@
+apiVersion: kargo.akuity.io/v1alpha1
+kind: ProjectConfig
+metadata:
+  name: kargo-kargo
+  namespace: kargo-kargo
+spec:
+  promotionPolicies:
+    - stage: main
+      autoPromotionEnabled: true

--- a/kargo-projects/traefik/kustomization.yaml
+++ b/kargo-projects/traefik/kustomization.yaml
@@ -2,5 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - project.yaml
+- projectconfig.yaml
 - warehouse.yaml
 - stage.yaml

--- a/kargo-projects/traefik/project.yaml
+++ b/kargo-projects/traefik/project.yaml
@@ -2,7 +2,3 @@ apiVersion: kargo.akuity.io/v1alpha1
 kind: Project
 metadata:
   name: kargo-traefik
-spec:
-  promotionPolicies:
-    - stage: main
-      autoPromotionEnabled: true

--- a/kargo-projects/traefik/projectconfig.yaml
+++ b/kargo-projects/traefik/projectconfig.yaml
@@ -1,0 +1,9 @@
+apiVersion: kargo.akuity.io/v1alpha1
+kind: ProjectConfig
+metadata:
+  name: kargo-traefik
+  namespace: kargo-traefik
+spec:
+  promotionPolicies:
+    - stage: main
+      autoPromotionEnabled: true


### PR DESCRIPTION
## Summary

Kargo 1.10 (just pulled in via #53) made a breaking change: `Project.spec` is gone. All per-project configuration — `promotionPolicies` and future `webhookReceivers` — lives in a new `ProjectConfig` CR in the project's namespace.

This wasn't flagged in the v1.10.0 release notes the LLM surfaced before #53 (it only called out `freightMetadata`). It surfaced post-upgrade as ArgoCD failing on every Project with:

```
.spec: field not declared in schema
```

Which also blocked PR #52's `continueOnError` from propagating to Stage CRs (`kargo-projects` App couldn't sync at all).

## Fix

For each of the 6 projects:
- `project.yaml`: stripped to metadata-only (just `apiVersion` / `kind` / `metadata.name`)
- `projectconfig.yaml` (new): same name, scoped to the project's namespace, holds the `promotionPolicies`
- `kustomization.yaml`: now lists `projectconfig.yaml` after `project.yaml`

## Test plan

- [ ] After merge, `kubectl get application kargo-projects -n argocd` shows `Synced/Healthy` with no comparison errors
- [ ] `kubectl get projectconfigs -A` lists all 6
- [ ] `kubectl get stage main -n kargo-kargo -o jsonpath='{.spec.promotionTemplate.spec.steps[1]}'` finally shows `continueOnError: true` (which has been queued in the source since #52)
- [ ] kargo-kargo's next promotion completes; live picks up `cluster/kargo.yaml` + `cluster/kargo-projects.yaml` + `cluster/cluster.yaml` + `kargo/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)