### PR TITLE
Cutover ArgoCD apps to live (Phase 6 redo)

### DIFF
--- a/cluster/argocd.yaml
+++ b/cluster/argocd.yaml
@@ -17,10 +17,10 @@ spec:
         valueFiles:
           - $values/argocd/values.yaml
     - repoURL: 'https://github.com/andyleap-cluster/cluster.git'
-      targetRevision: master
+      targetRevision: live
       ref: values
     - repoURL: 'https://github.com/andyleap-cluster/cluster.git'
-      targetRevision: master
+      targetRevision: live
       path: argocd/extras
   destination:
     server: 'https://kubernetes.default.svc'

--- a/cluster/cert-manager-webhook-linode.yaml
+++ b/cluster/cert-manager-webhook-linode.yaml
@@ -17,7 +17,7 @@ spec:
         valueFiles:
           - $values/cert-manager-webhook-linode/values.yaml
     - repoURL: 'https://github.com/andyleap-cluster/cluster.git'
-      targetRevision: master
+      targetRevision: live
       ref: values
   destination:
     server: 'https://kubernetes.default.svc'

--- a/cluster/cert-manager.yaml
+++ b/cluster/cert-manager.yaml
@@ -17,10 +17,10 @@ spec:
         valueFiles:
           - $values/cert-manager/values.yaml
     - repoURL: 'https://github.com/andyleap-cluster/cluster.git'
-      targetRevision: master
+      targetRevision: live
       ref: values
     - repoURL: 'https://github.com/andyleap-cluster/cluster.git'
-      targetRevision: master
+      targetRevision: live
       path: cert-manager/extras
   destination:
     server: 'https://kubernetes.default.svc'

--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -10,7 +10,7 @@ spec:
   source:
     repoURL: 'https://github.com/andyleap-cluster/cluster.git'
     path: cluster
-    targetRevision: master
+    targetRevision: live
   destination:
     server: 'https://kubernetes.default.svc'
     namespace: argocd

--- a/cluster/gateway-api.yaml
+++ b/cluster/gateway-api.yaml
@@ -12,7 +12,7 @@ spec:
   source:
     repoURL: 'https://github.com/andyleap-cluster/cluster.git'
     path: gateway-api
-    targetRevision: master
+    targetRevision: live
   destination:
     server: 'https://kubernetes.default.svc'
     namespace: default

--- a/cluster/kargo.yaml
+++ b/cluster/kargo.yaml
@@ -15,10 +15,10 @@ spec:
         valueFiles:
           - $values/kargo/values.yaml
     - repoURL: 'https://github.com/andyleap-cluster/cluster.git'
-      targetRevision: master
+      targetRevision: live
       ref: values
     - repoURL: 'https://github.com/andyleap-cluster/cluster.git'
-      targetRevision: master
+      targetRevision: live
       path: kargo/extras
   destination:
     server: 'https://kubernetes.default.svc'

--- a/cluster/traefik.yaml
+++ b/cluster/traefik.yaml
@@ -17,10 +17,10 @@ spec:
         valueFiles:
           - $values/traefik/values.yaml
     - repoURL: 'https://github.com/andyleap-cluster/cluster.git'
-      targetRevision: master
+      targetRevision: live
       ref: values
     - repoURL: 'https://github.com/andyleap-cluster/cluster.git'
-      targetRevision: master
+      targetRevision: live
       path: traefik/extras
   destination:
     server: 'https://kubernetes.default.svc'


### PR DESCRIPTION
## Summary

Phase 6 redo — flips `targetRevision: master` → `live` on:
- `cluster/cluster.yaml` (root scans `cluster/` from live)
- `cluster/argocd.yaml`, `cert-manager.yaml`, `cert-manager-webhook-linode.yaml`, `gateway-api.yaml`, `traefik.yaml`, `kargo.yaml` (the this-repo sources for values + extras)

`cluster/kargo-projects.yaml` **stays on master**: the Kargo project/warehouse/stage definitions are human-authored. Kargo doesn't promote into `kargo-projects/`, so that directory only exists on master.

Live is already fully populated (kargo-kargo's first promotion succeeded earlier — `cluster/{kargo,kargo-projects,cluster}.yaml` + `kargo/` are all there now, plus each app's slice).

## ⚠ Post-merge runbook (must run)

After this PR merges, immediately:

```
git fetch
git push origin master:live --force-with-lease
```

Why: live's current `cluster/cluster.yaml` and child manifests still have `targetRevision: master` (kargo-kargo copied them before this PR existed). Without the force-push, ArgoCD's reconcile after merge would read `cluster.yaml` from master (says live), update the cluster App to live, then read `cluster.yaml` from live (says master), flip back. Up to ~6 min of ping-pong until the cluster-repo Warehouse pulls the new commit and Kargo Stages re-promote.

The force-push makes live identical to master at this PR's tip, so both branches agree on every targetRevision. Kargo's next polling cycle will re-apply each Stage's bump on top, but starting from a clean baseline.

## Test plan

Right after running the force-push:
- [ ] `kubectl get application cluster -n argocd -o jsonpath='{.spec.source.targetRevision}'` returns `live`
- [ ] All 8 ArgoCD Apps reach Synced/Healthy within ~5 min
- [ ] `kargo.andyleap.dev`, `argocd.andyleap.dev` still serve
- [ ] Within Kargo's poll interval, fresh promotions appear on live ("kargo: bump X to Y") and each App stays Healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)
