### PR TITLE
Allow argo-cd chart 9.x in Kargo warehouse

### DIFF
--- a/kargo-projects/argocd/warehouse.yaml
+++ b/kargo-projects/argocd/warehouse.yaml
@@ -8,7 +8,7 @@ spec:
     - chart:
         repoURL: https://argoproj.github.io/argo-helm
         name: argo-cd
-        semverConstraint: ">=8.0.0 <9.0.0"
+        semverConstraint: ">=8.0.0 <10.0.0"
     - git:
         repoURL: https://github.com/andyleap-cluster/cluster.git
         branch: master


### PR DESCRIPTION
## Summary

The argo-cd Helm chart is at 9.x now. Bump the Kargo warehouse constraint from \`>=8.0.0 <9.0.0\` to \`>=8.0.0 <10.0.0\` so it can discover and promote 9.x releases.

## Test plan

- [ ] After merge, kargo-argocd Warehouse re-discovers latest chart (likely 9.x)
- [ ] argocd Stage's next promotion bumps \`cluster/argocd.yaml\` targetRevision to the 9.x version
- [ ] After ArgoCD applies the new chart, kargo App on the argocd Application stays Synced/Healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)