### PR TITLE
kargo-kargo Stage mirrors kargo-projects/ to live

### DIFF
--- a/kargo-projects/kargo/stage.yaml
+++ b/kargo-projects/kargo/stage.yaml
@@ -34,6 +34,17 @@ spec:
           config:
             inPath: ./src/kargo
             outPath: ./out/kargo
+        # Also mirror the kargo-projects/ directory so the project/warehouse/
+        # stage defs are available on live. Lets cluster/kargo-projects.yaml
+        # point at live for consistency with the other Apps.
+        - uses: git-clear
+          continueOnError: true
+          config:
+            path: ./out/kargo-projects
+        - uses: copy
+          config:
+            inPath: ./src/kargo-projects
+            outPath: ./out/kargo-projects
         # Three single-file copies for unowned ArgoCD Application manifests.
         # Putting them in this Stage's slice prevents the root cluster App
         # from pruning the kargo/kargo-projects/cluster Apps after cutover.


### PR DESCRIPTION
## Summary

Extends the kargo-kargo Stage's owned slice to also include `kargo-projects/`. With this, every change to kargo-projects/ on master flows into live via Kargo (just like every other app), and a follow-up PR can flip `cluster/kargo-projects.yaml` from `targetRevision: master` to `live` for consistency.

Standard 3-step pattern (git-clear with continueOnError → copy):
- `git-clear ./out/kargo-projects` (continueOnError handles first-time-no-dir case)
- `copy ./src/kargo-projects → ./out/kargo-projects`

## Two-step rollout

1. **This PR**: extend Stage. After merge + one kargo-kargo promotion (~5 min poll), live has `kargo-projects/` populated. cluster/kargo-projects.yaml still on master so no deploy-path change.
2. **Follow-up**: flip `cluster/kargo-projects.yaml` to `targetRevision: live`. Safe because step 1 guaranteed live has the content.

## Test plan

- [ ] After merge, kargo-kargo Stage's next promotion completes
- [ ] `git ls-tree origin/live kargo-projects/` shows the project defs
- [ ] kargo-projects ArgoCD App stays Synced/Healthy (still reading from master, no change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)