### PR TITLE
Give kargo-projects and cluster their own Kargo pipelines

### DIFF
--- a/kargo-projects/cluster/kustomization.yaml
+++ b/kargo-projects/cluster/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - project.yaml
+  - projectconfig.yaml
+  - warehouse.yaml
+  - stage.yaml

--- a/kargo-projects/cluster/project.yaml
+++ b/kargo-projects/cluster/project.yaml
@@ -1,0 +1,4 @@
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Project
+metadata:
+  name: kargo-cluster

--- a/kargo-projects/cluster/projectconfig.yaml
+++ b/kargo-projects/cluster/projectconfig.yaml
@@ -1,0 +1,9 @@
+apiVersion: kargo.akuity.io/v1alpha1
+kind: ProjectConfig
+metadata:
+  name: kargo-cluster
+  namespace: kargo-cluster
+spec:
+  promotionPolicies:
+    - stage: main
+      autoPromotionEnabled: true

--- a/kargo-projects/cluster/stage.yaml
+++ b/kargo-projects/cluster/stage.yaml
@@ -1,0 +1,37 @@
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+metadata:
+  name: main
+  namespace: kargo-cluster
+spec:
+  requestedFreight:
+    - origin:
+        kind: Warehouse
+        name: cluster
+      sources:
+        direct: true
+  promotionTemplate:
+    spec:
+      steps:
+        - uses: git-clone
+          config:
+            repoURL: git@github.com:andyleap-cluster/cluster.git
+            checkout:
+              - branch: master
+                path: ./src
+              - branch: live
+                create: true
+                path: ./out
+        - uses: copy
+          config:
+            inPath: ./src/cluster/cluster.yaml
+            outPath: ./out/cluster/cluster.yaml
+        - uses: git-commit
+          config:
+            path: ./out
+            message: |
+              kargo: mirror cluster.yaml to live
+        - uses: git-push
+          config:
+            path: ./out
+            targetBranch: live

--- a/kargo-projects/cluster/warehouse.yaml
+++ b/kargo-projects/cluster/warehouse.yaml
@@ -1,0 +1,14 @@
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Warehouse
+metadata:
+  name: cluster
+  namespace: kargo-cluster
+spec:
+  subscriptions:
+    # No upstream — the root cluster ArgoCD App's manifest is purely
+    # human-authored. Mirror master to live on each commit.
+    - git:
+        repoURL: https://github.com/andyleap-cluster/cluster.git
+        branch: master
+        commitSelectionStrategy: NewestFromBranch
+        strictSemvers: false

--- a/kargo-projects/kargo-projects/kustomization.yaml
+++ b/kargo-projects/kargo-projects/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - project.yaml
+  - projectconfig.yaml
+  - warehouse.yaml
+  - stage.yaml

--- a/kargo-projects/kargo-projects/project.yaml
+++ b/kargo-projects/kargo-projects/project.yaml
@@ -1,0 +1,4 @@
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Project
+metadata:
+  name: kargo-kargo-projects

--- a/kargo-projects/kargo-projects/projectconfig.yaml
+++ b/kargo-projects/kargo-projects/projectconfig.yaml
@@ -1,0 +1,9 @@
+apiVersion: kargo.akuity.io/v1alpha1
+kind: ProjectConfig
+metadata:
+  name: kargo-kargo-projects
+  namespace: kargo-kargo-projects
+spec:
+  promotionPolicies:
+    - stage: main
+      autoPromotionEnabled: true

--- a/kargo-projects/kargo-projects/stage.yaml
+++ b/kargo-projects/kargo-projects/stage.yaml
@@ -1,0 +1,48 @@
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+metadata:
+  name: main
+  namespace: kargo-kargo-projects
+spec:
+  requestedFreight:
+    - origin:
+        kind: Warehouse
+        name: kargo-projects
+      sources:
+        direct: true
+  promotionTemplate:
+    spec:
+      steps:
+        - uses: git-clone
+          config:
+            repoURL: git@github.com:andyleap-cluster/cluster.git
+            checkout:
+              - branch: master
+                path: ./src
+              - branch: live
+                create: true
+                path: ./out
+        # Mirror the kargo-projects/ directory (project, warehouse, stage,
+        # projectconfig defs for every Kargo pipeline) from master to live.
+        - uses: git-clear
+          continueOnError: true
+          config:
+            path: ./out/kargo-projects
+        - uses: copy
+          config:
+            inPath: ./src/kargo-projects
+            outPath: ./out/kargo-projects
+        # Copy this pipeline's own ArgoCD App manifest so it ends up on live.
+        - uses: copy
+          config:
+            inPath: ./src/cluster/kargo-projects.yaml
+            outPath: ./out/cluster/kargo-projects.yaml
+        - uses: git-commit
+          config:
+            path: ./out
+            message: |
+              kargo: mirror kargo-projects to live
+        - uses: git-push
+          config:
+            path: ./out
+            targetBranch: live

--- a/kargo-projects/kargo-projects/warehouse.yaml
+++ b/kargo-projects/kargo-projects/warehouse.yaml
@@ -1,0 +1,14 @@
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Warehouse
+metadata:
+  name: kargo-projects
+  namespace: kargo-kargo-projects
+spec:
+  subscriptions:
+    # No upstream chart/image — this pipeline just mirrors human-authored
+    # project defs from master to live.
+    - git:
+        repoURL: https://github.com/andyleap-cluster/cluster.git
+        branch: master
+        commitSelectionStrategy: NewestFromBranch
+        strictSemvers: false

--- a/kargo-projects/kargo/stage.yaml
+++ b/kargo-projects/kargo/stage.yaml
@@ -34,32 +34,13 @@ spec:
           config:
             inPath: ./src/kargo
             outPath: ./out/kargo
-        # Also mirror the kargo-projects/ directory so the project/warehouse/
-        # stage defs are available on live. Lets cluster/kargo-projects.yaml
-        # point at live for consistency with the other Apps.
-        - uses: git-clear
-          continueOnError: true
-          config:
-            path: ./out/kargo-projects
-        - uses: copy
-          config:
-            inPath: ./src/kargo-projects
-            outPath: ./out/kargo-projects
-        # Three single-file copies for unowned ArgoCD Application manifests.
-        # Putting them in this Stage's slice prevents the root cluster App
-        # from pruning the kargo/kargo-projects/cluster Apps after cutover.
+        # Copy this Stage's own ArgoCD App manifest. cluster/cluster.yaml
+        # is owned by the kargo-cluster pipeline; cluster/kargo-projects.yaml
+        # by kargo-kargo-projects.
         - uses: copy
           config:
             inPath: ./src/cluster/kargo.yaml
             outPath: ./out/cluster/kargo.yaml
-        - uses: copy
-          config:
-            inPath: ./src/cluster/kargo-projects.yaml
-            outPath: ./out/cluster/kargo-projects.yaml
-        - uses: copy
-          config:
-            inPath: ./src/cluster/cluster.yaml
-            outPath: ./out/cluster/cluster.yaml
         # Bump the kargo chart targetRevision to whatever the warehouse
         # discovered.
         - uses: yaml-update

--- a/kargo-projects/kustomization.yaml
+++ b/kargo-projects/kustomization.yaml
@@ -5,6 +5,8 @@ resources:
   - argocd
   - cert-manager
   - cert-manager-webhook-linode
+  - cluster
   - gateway-api
   - kargo
+  - kargo-projects
   - traefik


### PR DESCRIPTION
## Summary

Both `cluster/kargo-projects.yaml` and `cluster/cluster.yaml` are ArgoCD Apps. By the "one pipeline per App" rule they each deserve their own Kargo pipeline rather than being bundled into kargo-kargo's slice (which #57 prematurely did for kargo-projects).

### Two new pipelines (pure repo-to-repo, no upstream chart/image)

| Pipeline | Owns | Subscribes to |
|---|---|---|
| `kargo-kargo-projects` | `cluster/kargo-projects.yaml` + `kargo-projects/` dir | cluster-repo `master` |
| `kargo-cluster` | `cluster/cluster.yaml` | cluster-repo `master` |

### kargo-kargo trimmed

Now owns just its own slice: `kargo/` directory + `cluster/kargo.yaml`. Bumps the kargo chart targetRevision as before. No more single-file copies for other Apps' manifests.

### Why repo-to-repo

No version bumps to apply — these are human-authored configs. The pipelines exist so the live branch is fully Kargo-managed (consistent pattern across all 8 ArgoCD Apps) and pushing to master triggers a copy via the cluster-repo Warehouse.

### Follow-up

After these pipelines have promoted at least once and live has the content, separate PR will flip `cluster/kargo-projects.yaml` to `targetRevision: live`. `cluster/cluster.yaml`'s manifest is already at `targetRevision: live` from #55.

## Test plan

- [ ] After merge, all 8 pipelines have a Stage + Warehouse Ready
- [ ] `kubectl get projectconfig -A` lists 8
- [ ] Both new pipelines promote within ~5 min
- [ ] `git ls-tree origin/live cluster/` and `kargo-projects/` show full content on live
- [ ] kargo-projects and cluster ArgoCD Apps remain Synced/Healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)
