### PR TITLE
Wire argocd-update + flip kargo-projects.yaml to live

### DIFF
--- a/cluster/cluster.yaml
+++ b/cluster/cluster.yaml
@@ -3,6 +3,8 @@ kind: Application
 metadata:
   name: cluster
   namespace: argocd
+  annotations:
+    kargo.akuity.io/authorized-stage: "kargo-cluster:main"
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/cluster/kargo-projects.yaml
+++ b/cluster/kargo-projects.yaml
@@ -3,6 +3,8 @@ kind: Application
 metadata:
   name: kargo-projects
   namespace: argocd
+  annotations:
+    kargo.akuity.io/authorized-stage: "kargo-kargo-projects:main"
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:
@@ -10,7 +12,7 @@ spec:
   source:
     repoURL: 'https://github.com/andyleap-cluster/cluster.git'
     path: kargo-projects
-    targetRevision: master
+    targetRevision: live
   destination:
     server: 'https://kubernetes.default.svc'
     namespace: default

--- a/cluster/kargo.yaml
+++ b/cluster/kargo.yaml
@@ -3,6 +3,8 @@ kind: Application
 metadata:
   name: kargo
   namespace: argocd
+  annotations:
+    kargo.akuity.io/authorized-stage: "kargo-kargo:main"
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/kargo-projects/argocd/stage.yaml
+++ b/kargo-projects/argocd/stage.yaml
@@ -54,3 +54,8 @@ spec:
           config:
             path: ./out
             targetBranch: live
+        - uses: argocd-update
+          config:
+            apps:
+              - name: argocd
+                namespace: argocd

--- a/kargo-projects/cert-manager-webhook-linode/stage.yaml
+++ b/kargo-projects/cert-manager-webhook-linode/stage.yaml
@@ -57,3 +57,8 @@ spec:
           config:
             path: ./out
             targetBranch: live
+        - uses: argocd-update
+          config:
+            apps:
+              - name: cert-manager-webhook-linode
+                namespace: argocd

--- a/kargo-projects/cert-manager/stage.yaml
+++ b/kargo-projects/cert-manager/stage.yaml
@@ -51,3 +51,8 @@ spec:
           config:
             path: ./out
             targetBranch: live
+        - uses: argocd-update
+          config:
+            apps:
+              - name: cert-manager
+                namespace: argocd

--- a/kargo-projects/cluster/stage.yaml
+++ b/kargo-projects/cluster/stage.yaml
@@ -35,3 +35,8 @@ spec:
           config:
             path: ./out
             targetBranch: live
+        - uses: argocd-update
+          config:
+            apps:
+              - name: cluster
+                namespace: argocd

--- a/kargo-projects/gateway-api/stage.yaml
+++ b/kargo-projects/gateway-api/stage.yaml
@@ -53,3 +53,8 @@ spec:
           config:
             path: ./out
             targetBranch: live
+        - uses: argocd-update
+          config:
+            apps:
+              - name: gateway-api
+                namespace: argocd

--- a/kargo-projects/kargo-projects/stage.yaml
+++ b/kargo-projects/kargo-projects/stage.yaml
@@ -46,3 +46,8 @@ spec:
           config:
             path: ./out
             targetBranch: live
+        - uses: argocd-update
+          config:
+            apps:
+              - name: kargo-projects
+                namespace: argocd

--- a/kargo-projects/kargo/stage.yaml
+++ b/kargo-projects/kargo/stage.yaml
@@ -58,3 +58,8 @@ spec:
           config:
             path: ./out
             targetBranch: live
+        - uses: argocd-update
+          config:
+            apps:
+              - name: kargo
+                namespace: argocd

--- a/kargo-projects/traefik/stage.yaml
+++ b/kargo-projects/traefik/stage.yaml
@@ -57,3 +57,8 @@ spec:
           config:
             path: ./out
             targetBranch: live
+        - uses: argocd-update
+          config:
+            apps:
+              - name: traefik
+                namespace: argocd


### PR DESCRIPTION
## Summary

Three coupled cleanups now that the live branch is fully Kargo-managed across all 8 Apps:

### 1. Flip `cluster/kargo-projects.yaml` to `targetRevision: live`

The follow-up from #58 — kargo-kargo-projects Stage has populated `kargo-projects/` and `cluster/kargo-projects.yaml` on live, so safe to read from live now. Consistent with every other App.

### 2. Add `argocd-update` step to all 8 Stages

Dropped from Stages during Phase 5's shadow run because the Apps were pinned to master — argocd-update waits for the App to reach the freight's revisions, which it never would. Now that Apps read from live and Kargo writes to live, the step works as designed: each promotion finishes with an immediate ArgoCD sync nudge instead of waiting ~3 min for the next poll cycle.

```yaml
- uses: argocd-update
  config:
    apps:
      - name: <app>
        namespace: argocd
```

### 3. Add missing `kargo.akuity.io/authorized-stage` annotations

- `cluster/cluster.yaml` → `kargo-cluster:main` (added with the new pipeline in #58)
- `cluster/kargo.yaml` → `kargo-kargo:main` (missed in Phase 5)
- `cluster/kargo-projects.yaml` → `kargo-kargo-projects:main` (added with the new pipeline in #58)

`argocd-update` won't mutate an App without this annotation, so these are required.

## Test plan

- [ ] After merge, each Kargo Stage's next promotion completes through `argocd-update` (no `unauthorized stage` errors)
- [ ] The corresponding ArgoCD App syncs immediately rather than waiting for the next poll
- [ ] `cluster/kargo-projects.yaml` ArgoCD App stays Synced/Healthy after the targetRevision flip
- [ ] No App churn

🤖 Generated with [Claude Code](https://claude.com/claude-code)
