### PR TITLE
Fix kargo-projects drift + traefik CRD-downgrade block

### DIFF
--- a/cluster/kargo-projects.yaml
+++ b/cluster/kargo-projects.yaml
@@ -22,3 +22,15 @@ spec:
       prune: true
     syncOptions:
     - ServerSideApply=true
+  ignoreDifferences:
+    # Kargo's controller defaults fields on Warehouse and Stage resources
+    # (freightCreationPolicy, interval, discoveryLimit, etc.). Ignore the
+    # `kargo` field manager's writes so ArgoCD doesn't churn.
+    - group: kargo.akuity.io
+      kind: Warehouse
+      managedFieldsManagers:
+        - kargo
+    - group: kargo.akuity.io
+      kind: Stage
+      managedFieldsManagers:
+        - kargo

--- a/cluster/traefik.yaml
+++ b/cluster/traefik.yaml
@@ -14,6 +14,11 @@ spec:
       chart: traefik
       targetRevision: 34.4.1
       helm:
+        # The traefik chart bundles older Gateway API CRDs in crds/. The
+        # gateway-api App owns the cluster's Gateway API CRDs (newer), and
+        # the cluster's safe-upgrades ValidatingAdmissionPolicy blocks
+        # downgrades. Skip the chart's CRDs.
+        skipCrds: true
         valueFiles:
           - $values/traefik/values.yaml
     - repoURL: 'https://github.com/andyleap-cluster/cluster.git'


### PR DESCRIPTION
## Summary

Two unrelated cluster-state issues surfaced post-#59:

### 1. kargo-projects App OutOfSync on all 8 Warehouses

Kargo's controller adds defaulted fields on every Warehouse/Stage (`freightCreationPolicy: Automatic`, `interval: 5m0s`, `discoveryLimit: 20`) via the `kargo` field manager. ArgoCD's SSA-diff sees those as drift.

Fix: add `ignoreDifferences` with `managedFieldsManagers: [kargo]` on Warehouse and Stage in [cluster/kargo-projects.yaml](cluster/kargo-projects.yaml). Same pattern we used for the kargo App in #34 (`managedFieldsManagers: [kube-controller-manager]`).

### 2. traefik App failing to sync

```
customresourcedefinitions ... is forbidden: ValidatingAdmissionPolicy
'safe-upgrades.gateway.networking.k8s.io' ... denied request:
Installing CRDs with version before v1.5.0 is prohibited by default.
```

The traefik chart bundles older Gateway API CRDs (v1.2-ish) in its `crds/` directory. The cluster has Gateway API v1.5.1 from the gateway-api App, with a `safe-upgrades` ValidatingAdmissionPolicy that prevents installing older CRDs.

Fix: set `helm.skipCrds: true` on the traefik chart source so ArgoCD doesn't try to install the bundled CRDs. The gateway-api App keeps owning Gateway API CRDs.

## Test plan

- [ ] After merge, `kubectl get application kargo-projects -n argocd` reaches `Synced/Healthy`
- [ ] `kubectl get application traefik -n argocd` reaches `Synced/Healthy`
- [ ] `kubectl get crd | grep gateway.networking.k8s.io` still shows v1.5.1 (unchanged)
- [ ] Traefik pods running

🤖 Generated with [Claude Code](https://claude.com/claude-code)
