### PR TITLE
Allow traefik chart up to 40.x in Kargo warehouse

### DIFF
--- a/kargo-projects/traefik/warehouse.yaml
+++ b/kargo-projects/traefik/warehouse.yaml
@@ -8,7 +8,7 @@ spec:
     - chart:
         repoURL: https://traefik.github.io/charts
         name: traefik
-        semverConstraint: ">=34.0.0 <35.0.0"
+        semverConstraint: ">=34.0.0 <41.0.0"
     - image:
         repoURL: docker.io/traefik
         imageSelectionStrategy: SemVer


### PR DESCRIPTION
## Summary

Traefik chart is at 40.x now. Loosen the Kargo warehouse semver constraint from \`>=34.0.0 <35.0.0\` to \`>=34.0.0 <41.0.0\` so Kargo can promote forward through the missing 6 majors.

## Heads-up

Jumping from 34.x to 40.x crosses several majors with likely Helm values breaking changes. Things to watch after the first promotion:

- \`cluster/traefik.yaml\` on live will get its chart targetRevision bumped to the latest matching
- traefik App may go OutOfSync if [traefik/values.yaml](traefik/values.yaml) has keys that moved/renamed
- image.tag bumps will follow via the image subscription (\`>=3.0.0 <4.0.0\` — still v3.x; check whether chart 40.x's appVersion is in that range)

If values break, the fix is in traefik/values.yaml on master; Kargo's next promotion will copy the corrections to live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)