### PR TITLE
Fix kargo-projects drift + traefik 40.x schema + drop image pins

### DIFF
--- a/cert-manager-webhook-linode/values.yaml
+++ b/cert-manager-webhook-linode/values.yaml
@@ -18,7 +18,6 @@ deployment:
 
 image:
   repository: linode/cert-manager-webhook-linode
-  tag: v0.3.0
   pullPolicy: IfNotPresent
 
 service:

--- a/cluster/kargo-projects.yaml
+++ b/cluster/kargo-projects.yaml
@@ -23,14 +23,15 @@ spec:
     syncOptions:
     - ServerSideApply=true
   ignoreDifferences:
-    # Kargo's controller defaults fields on Warehouse and Stage resources
-    # (freightCreationPolicy, interval, discoveryLimit, etc.). Ignore the
-    # `kargo` field manager's writes so ArgoCD doesn't churn.
+    # The Kargo API server defaults these fields on Warehouses without
+    # recording ownership in managedFields (server-side defaulting, not an
+    # Apply by a tracked manager). managedFieldsManagers therefore can't
+    # catch them — list the specific paths explicitly. Stages show no drift.
     - group: kargo.akuity.io
       kind: Warehouse
-      managedFieldsManagers:
-        - kargo
-    - group: kargo.akuity.io
-      kind: Stage
-      managedFieldsManagers:
-        - kargo
+      jqPathExpressions:
+        - .spec.freightCreationPolicy
+        - .spec.interval
+        - .spec.subscriptions[].chart.discoveryLimit
+        - .spec.subscriptions[].image.discoveryLimit
+        - .spec.subscriptions[].git.discoveryLimit

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -1,9 +1,6 @@
 # Traefik Helm Chart values
 # https://github.com/traefik/traefik-helm-chart
 
-image:
-  tag: v3.2
-
 # Deployment configuration
 deployment:
   replicas: 1
@@ -24,8 +21,9 @@ ports:
       default: true
     exposedPort: 443
     protocol: TCP
-    tls:
-      enabled: true
+    http:
+      tls:
+        enabled: true
   traefik:
     port: 8080
     expose:
@@ -56,10 +54,6 @@ providers:
 # Gateway API - disable helm chart Gateway, we create it manually for full control
 gateway:
   enabled: false
-
-# Enable ping for health checks
-ping:
-  entryPoint: traefik
 
 # Disable dashboard exposure (access via port-forward if needed)
 ingressRoute:


### PR DESCRIPTION
## Summary

Three coupled cleanups for post-cutover issues:

### 1. kargo-projects App was still OutOfSync after #60

The previous fix used `managedFieldsManagers: [kargo]`, but Kargo's API server defaults `freightCreationPolicy`, `interval`, and `discoveryLimit` *server-side* without recording any manager in `managedFields`. ArgoCD sees them as drift with no manager to ignore.

Switched to `jqPathExpressions` listing the exact defaulted paths:

```yaml
ignoreDifferences:
  - group: kargo.akuity.io
    kind: Warehouse
    jqPathExpressions:
      - .spec.freightCreationPolicy
      - .spec.interval
      - .spec.subscriptions[].chart.discoveryLimit
      - .spec.subscriptions[].image.discoveryLimit
      - .spec.subscriptions[].git.discoveryLimit
```

(Stages don't drift — only Warehouses needed.)

### 2. traefik values schema errors against chart 40.x

After #61 let Kargo bump traefik chart to 40.2.0, the App went Unknown with:
```
- at '/ports/websecure': additional properties 'tls' not allowed
- at '': additional properties 'ping' not allowed
```

Chart 40.x:
- Moved `ports.<entry>.tls` to `ports.<entry>.http.tls`
- Removed top-level `ping:` config (chart now has implicit liveness/readiness via `healthchecksPort`/`readinessPath` defaults)

Updated `traefik/values.yaml`. Tested rendering against chart 40.2.0.

### 3. Drop master's image.tag pins (traefik + cert-manager-webhook-linode)

Kargo's per-app Stages already write `image.tag` to live via `yaml-update` on every promotion, so master's pin never actually deployed (ArgoCD reads from live post-cutover). The pinned values were a misleading source of truth.

Removed them. Chart's appVersion now serves as the natural fallback for any out-of-Kargo render. Kargo continues to write the discovered version into live's values.yaml.

## Test plan

- [ ] After merge, kargo-projects App reaches Synced/Healthy (no more 8 OutOfSync Warehouses)
- [ ] traefik App reaches Synced/Healthy after next kargo-traefik promotion
- [ ] traefik pods running, gateway listeners serving on 80/443
- [ ] cert-manager-webhook-linode still functional (image version comes from chart appVersion or Kargo's write)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
