### PR TITLE
Restore image.tag placeholders for yaml-update

### DIFF
--- a/cert-manager-webhook-linode/values.yaml
+++ b/cert-manager-webhook-linode/values.yaml
@@ -18,6 +18,11 @@ deployment:
 
 image:
   repository: linode/cert-manager-webhook-linode
+  # Placeholder so Kargo's yaml-update can mutate this key. Kargo writes
+  # the discovered version on every promotion. The chart's template does
+  # `{{ .repository }}:{{ .tag }}` with no fallback, so this must be
+  # non-empty for out-of-Kargo renders.
+  tag: v0.4.1
   pullPolicy: IfNotPresent
 
 service:

--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -1,6 +1,13 @@
 # Traefik Helm Chart values
 # https://github.com/traefik/traefik-helm-chart
 
+# Image tag: a placeholder so Kargo's yaml-update can mutate this key.
+# Kargo writes the discovered version on every promotion. ArgoCD reads
+# from live, so this master value only matters as a fallback for
+# out-of-Kargo renders (e.g. helm template locally).
+image:
+  tag: v3.7.0
+
 # Deployment configuration
 deployment:
   replicas: 1


### PR DESCRIPTION
## Summary

#62 dropped the \`image.tag\` keys entirely. Turns out Kargo's \`yaml-update\` step **mutates existing keys but doesn't create missing ones** — every traefik and cert-manager-webhook-linode promotion since the merge has been erroring:

\`\`\`
error finding key image.tag: key path not found
\`\`\`

Fix: reinstate the keys with sensible placeholder versions. The master values continue to be just a fallback (ArgoCD reads from live, where Kargo writes the discovered version on every promotion).

- \`traefik/values.yaml\`: \`image.tag: v3.7.0\` (matches chart 40.x's appVersion, so out-of-Kargo renders still produce a working image ref)
- \`cert-manager-webhook-linode/values.yaml\`: \`image.tag: v0.4.1\` (current latest; the chart template has no \`| default appVersion\` fallback, so the key must be non-empty)

## Test plan

- [ ] After merge, kargo-traefik Stage's next promotion completes (no key-not-found error)
- [ ] kargo-cert-manager-webhook-linode same
- [ ] \`git log master..live\` shows fresh "kargo: bump" commits for both
- [ ] Both Apps stay Synced/Healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)