### PR TITLE
Disable pruning on gateway-api Application (CRD swap prep, 1/6)

### DIFF
--- a/cluster/gateway-api.yaml
+++ b/cluster/gateway-api.yaml
@@ -3,10 +3,11 @@ kind: Application
 metadata:
   name: gateway-api
   namespace: argocd
+  # Retirement prep: prune:false and no finalizer let the next PR delete
+  # this Application without cascade-deleting its CRDs, so traefik-crds can
+  # adopt them in place.
   annotations:
     kargo.akuity.io/authorized-stage: "kargo-gateway-api:main"
-  finalizers:
-  - resources-finalizer.argocd.argoproj.io
 spec:
   project: default
   source:
@@ -19,6 +20,6 @@ spec:
   syncPolicy:
     automated:
       selfHeal: true
-      prune: true
+      prune: false
     syncOptions:
     - ServerSideApply=true


### PR DESCRIPTION
## Summary

First PR in a six-PR rollout that lands an IAP-style auth stack
(Pocket ID + oauth2-proxy + Traefik ForwardAuth). Full design at
[plans/iap-style-auth-stack-nested-cook.md](https://github.com/anthropics/claude-code/) (local plan file).

This PR alone is a no-op functionally — it only adjusts the
`gateway-api` ArgoCD Application so it can be retired safely in the
next PR:

- `automated.prune: true` → `false`
- removes the `resources-finalizer.argocd.argoproj.io` finalizer

Together these let PR 2/6 delete `cluster/gateway-api.yaml` + the
`gateway-api/` source dir without cascade-deleting the in-cluster
Gateway API CRDs. The follow-up `traefik-crds` Application will
re-adopt the (now orphaned) CRDs and upgrade them from v1.2.0 to
v1.5.1 via server-side apply.

## Test plan

- [ ] CI passes.
- [ ] After merge: Kargo `kargo-gateway-api:main` promotes to live;
      `kubectl -n argocd get app gateway-api -o yaml` shows
      `prune: false` and no finalizer.
- [ ] `kubectl get crd gateways.gateway.networking.k8s.io` still
      shows `v1` served (no functional regression).
- [ ] HTTPRoutes for `argocd.andyleap.dev` and `kargo.andyleap.dev`
      still resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)