### PR TITLE
Enable Traefik's kubernetesCRD provider (CRD swap, 3/6)

### DIFF
--- a/traefik/values.yaml
+++ b/traefik/values.yaml
@@ -52,7 +52,7 @@ resources:
 # Kubernetes providers
 providers:
   kubernetesCRD:
-    enabled: false
+    enabled: true
   kubernetesIngress:
     enabled: false
   kubernetesGateway:


### PR DESCRIPTION
## Summary

Third PR in the IAP auth-stack rollout. Flips
`providers.kubernetesCRD.enabled: false → true` in
[traefik/values.yaml](traefik/values.yaml#L54) so Traefik watches the
Middleware/IngressRoute/TLSStore/... CRDs that PR #65 installed via
the new `traefik-crds` App.

This is a no-op until something actually creates a Middleware in the
cluster (PR #5/6 will). But landing it now keeps Traefik in the
correct steady state before that PR, and Kargo will carry the values
change to live via the existing `kargo-traefik:main` Stage.

## Test plan

- [ ] CI passes.
- [ ] After merge: Kargo `kargo-traefik:main` promotes; the Traefik
      Deployment rolls out cleanly with the new value rendered into
      its args.
- [ ] `kubectl -n traefik logs deploy/traefik | grep -i kubernetescrd`
      shows the provider active.
- [ ] Existing HTTPRoutes (`argocd.andyleap.dev`, `kargo.andyleap.dev`)
      keep serving — no regression on the kubernetesGateway path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)