### PR TITLE
Switch cluster/ to kustomization-based source (orphan-prevention)

### DIFF
--- a/cluster/kustomization.yaml
+++ b/cluster/kustomization.yaml
@@ -1,0 +1,21 @@
+# Explicit list of Application files rendered by the parent `cluster`
+# ArgoCD Application. Listing each Application here (instead of letting
+# ArgoCD enumerate the directory) means that retiring an app is a
+# matter of removing one line: ArgoCD prunes the Application even if
+# the deleted file lingers on the live branch (which can happen because
+# per-app Kargo Stages don't propagate deletions of their own
+# cluster/<app>.yaml file).
+#
+# When adding or removing an app, update this list AND the per-app
+# files in the same PR.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - argocd.yaml
+  - cert-manager-webhook-linode.yaml
+  - cert-manager.yaml
+  - cluster.yaml
+  - kargo-projects.yaml
+  - kargo.yaml
+  - traefik-crds.yaml
+  - traefik.yaml

--- a/kargo-projects/cluster/stage.yaml
+++ b/kargo-projects/cluster/stage.yaml
@@ -26,11 +26,18 @@ spec:
           config:
             inPath: ./src/cluster/cluster.yaml
             outPath: ./out/cluster/cluster.yaml
+        # kustomization.yaml is what makes per-app retirements propagate
+        # to live: ArgoCD prunes Applications removed from the resources
+        # list even if the file lingers on live.
+        - uses: copy
+          config:
+            inPath: ./src/cluster/kustomization.yaml
+            outPath: ./out/cluster/kustomization.yaml
         - uses: git-commit
           config:
             path: ./out
             message: |
-              kargo: mirror cluster.yaml to live
+              kargo: mirror cluster.yaml + kustomization.yaml to live
         - uses: git-push
           config:
             path: ./out


### PR DESCRIPTION
## Summary

Structural follow-up to the gateway-api/traefik-crds migration. After PR #65 deleted `cluster/gateway-api.yaml` from master, the file lingered on the live branch indefinitely because:

1. The kargo-cluster Stage only copies `cluster/cluster.yaml` to live.
2. Each per-app Kargo Stage owns its respective `cluster/<app>.yaml`.
3. When an app is retired, the Stage that would have removed its file is itself deleted in the same PR, so nothing propagates the deletion.

This PR fixes the gap by switching the parent `cluster` Application's source from raw directory enumeration to a Kustomize-rendered manifest. The new `cluster/kustomization.yaml` explicitly lists every Application; retiring an app is now one line removed from this list, and ArgoCD prunes the Application regardless of whether the file lingers on live.

Also extends the kargo-cluster Stage to copy `cluster/kustomization.yaml` alongside `cluster.yaml` so changes propagate.

## Incidental effect

When kargo-cluster promotes this PR to live, the rendered manifest will no longer include the `gateway-api` Application (it's not in the new resources list). ArgoCD will prune the `gateway-api` Application object. Thanks to PR #64 (prune:false + no finalizer on gateway-api), the underlying CRDs remain in place, owned by `traefik-crds`. **This obsoletes #67** — that PR can be merged or closed; the end state is identical.

## Test plan

- [ ] CI passes.
- [ ] After merge: `kargo-cluster:main` promotes; live branch gains `cluster/kustomization.yaml`.
- [ ] ArgoCD `cluster` App still Synced/Healthy after the source-mode switch from directory → kustomize.
- [ ] `kubectl -n argocd get app` shows exactly 8 Applications, no gateway-api.
- [ ] `kubectl get crd middlewares.traefik.io` still present (owned by `traefik-crds`).
- [ ] `kubectl get crd gateways.gateway.networking.k8s.io -o jsonpath='{.metadata.annotations.gateway\.networking\.k8s\.io/bundle-version}'` still v1.5.1.
- [ ] HTTPRoutes for `argocd.andyleap.dev` and `kargo.andyleap.dev` still serving.

## Known limitations (out of scope)

Full directory retirements (e.g. `<retired-app>/` top-level dirs on live) are still not auto-cleaned by this change. Tracked separately as a follow-up for after the IAP rollout completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)