### PR TITLE
Deploy Pocket ID (IAP rollout, 4/6): hand-built Kustomize app + TF secret

### DIFF
--- a/cluster/kustomization.yaml
+++ b/cluster/kustomization.yaml
@@ -17,5 +17,6 @@ resources:
   - cluster.yaml
   - kargo-projects.yaml
   - kargo.yaml
+  - pocket-id.yaml
   - traefik-crds.yaml
   - traefik.yaml

--- a/cluster/pocket-id.yaml
+++ b/cluster/pocket-id.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: pocket-id
+  namespace: argocd
+  annotations:
+    kargo.akuity.io/authorized-stage: "kargo-pocket-id:main"
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: 'https://github.com/andyleap-cluster/cluster.git'
+    targetRevision: live
+    path: pocket-id
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: pocket-id
+  syncPolicy:
+    automated:
+      selfHeal: true
+      prune: true
+    syncOptions:
+    - CreateNamespace=true
+    - ServerSideApply=true

--- a/kargo-projects/kustomization.yaml
+++ b/kargo-projects/kustomization.yaml
@@ -8,5 +8,6 @@ resources:
   - cluster
   - kargo
   - kargo-projects
+  - pocket-id
   - traefik
   - traefik-crds

--- a/kargo-projects/pocket-id/kustomization.yaml
+++ b/kargo-projects/pocket-id/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- project.yaml
+- projectconfig.yaml
+- warehouse.yaml
+- stage.yaml

--- a/kargo-projects/pocket-id/project.yaml
+++ b/kargo-projects/pocket-id/project.yaml
@@ -1,0 +1,4 @@
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Project
+metadata:
+  name: kargo-pocket-id

--- a/kargo-projects/pocket-id/projectconfig.yaml
+++ b/kargo-projects/pocket-id/projectconfig.yaml
@@ -1,0 +1,9 @@
+apiVersion: kargo.akuity.io/v1alpha1
+kind: ProjectConfig
+metadata:
+  name: kargo-pocket-id
+  namespace: kargo-pocket-id
+spec:
+  promotionPolicies:
+    - stage: main
+      autoPromotionEnabled: true

--- a/kargo-projects/pocket-id/stage.yaml
+++ b/kargo-projects/pocket-id/stage.yaml
@@ -1,0 +1,58 @@
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+metadata:
+  name: main
+  namespace: kargo-pocket-id
+spec:
+  requestedFreight:
+    - origin:
+        kind: Warehouse
+        name: pocket-id
+      sources:
+        direct: true
+  promotionTemplate:
+    spec:
+      steps:
+        - uses: git-clone
+          config:
+            repoURL: git@github.com:andyleap-cluster/cluster.git
+            checkout:
+              - branch: master
+                path: ./src
+              - branch: live
+                create: true
+                path: ./out
+        - uses: git-clear
+          # First promotion against a fresh live has no ./out/pocket-id — that's
+          # expected; ignore the resulting "no such file or directory" error.
+          continueOnError: true
+          config:
+            path: ./out/pocket-id
+        - uses: copy
+          config:
+            inPath: ./src/cluster/pocket-id.yaml
+            outPath: ./out/cluster/pocket-id.yaml
+        - uses: copy
+          config:
+            inPath: ./src/pocket-id
+            outPath: ./out/pocket-id
+        - uses: yaml-update
+          config:
+            path: ./out/pocket-id/kustomization.yaml
+            updates:
+              - key: images.0.newTag
+                value: ${{ imageFrom("ghcr.io/pocket-id/pocket-id").Tag }}
+        - uses: git-commit
+          config:
+            path: ./out
+            message: |
+              kargo: bump pocket-id image to ${{ imageFrom("ghcr.io/pocket-id/pocket-id").Tag }}
+        - uses: git-push
+          config:
+            path: ./out
+            targetBranch: live
+        - uses: argocd-update
+          config:
+            apps:
+              - name: pocket-id
+                namespace: argocd

--- a/kargo-projects/pocket-id/warehouse.yaml
+++ b/kargo-projects/pocket-id/warehouse.yaml
@@ -1,0 +1,17 @@
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Warehouse
+metadata:
+  name: pocket-id
+  namespace: kargo-pocket-id
+spec:
+  subscriptions:
+    - image:
+        repoURL: ghcr.io/pocket-id/pocket-id
+        imageSelectionStrategy: SemVer
+        semverConstraint: ">=2.0.0 <3.0.0"
+        strictSemvers: true
+    - git:
+        repoURL: https://github.com/andyleap-cluster/cluster.git
+        branch: master
+        commitSelectionStrategy: NewestFromBranch
+        strictSemvers: false

--- a/pocket-id/configmap.yaml
+++ b/pocket-id/configmap.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pocket-id-config
+data:
+  HOST: "0.0.0.0"
+  PORT: "1411"
+  APP_URL: "https://id.andyleap.dev"
+  TRUST_PROXY: "true"
+  TZ: "Etc/UTC"
+  ANALYTICS_DISABLED: "false"
+  VERSION_CHECK_DISABLED: "true"
+  LOG_LEVEL: "info"
+  LOG_JSON: "false"
+  AUDIT_LOG_RETENTION_DAYS: "90"
+  DISABLE_RATE_LIMITING: "false"
+  FILE_BACKEND: "filesystem"
+  UPLOAD_PATH: "data/uploads"
+  DB_CONNECTION_STRING: "file:data/pocket-id.db"
+  TRACING_ENABLED: "false"
+  METRICS_ENABLED: "false"

--- a/pocket-id/httproute.yaml
+++ b/pocket-id/httproute.yaml
@@ -1,0 +1,24 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: pocket-id
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: traefik-gateway
+      namespace: traefik
+      sectionName: websecure
+  hostnames:
+    - id.andyleap.dev
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - group: ""
+          kind: Service
+          name: pocket-id
+          port: 80
+          weight: 1

--- a/pocket-id/kustomization.yaml
+++ b/pocket-id/kustomization.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: pocket-id
+
+resources:
+  - configmap.yaml
+  - service.yaml
+  - statefulset.yaml
+  - httproute.yaml
+
+# Kargo's kargo-pocket-id:main Stage rewrites images.0.newTag on each
+# promotion. The bootstrap Secret (ENCRYPTION_KEY) lives in Terraform,
+# not here, so this kustomization intentionally does not include it.
+images:
+  - name: ghcr.io/pocket-id/pocket-id
+    newTag: v2.6.2

--- a/pocket-id/service.yaml
+++ b/pocket-id/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: pocket-id
+  labels:
+    app.kubernetes.io/name: pocket-id
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: pocket-id
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+      protocol: TCP

--- a/pocket-id/statefulset.yaml
+++ b/pocket-id/statefulset.yaml
@@ -1,0 +1,75 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: pocket-id
+  labels:
+    app.kubernetes.io/name: pocket-id
+spec:
+  serviceName: pocket-id
+  replicas: 1
+  revisionHistoryLimit: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: pocket-id
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: pocket-id
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        fsGroup: 1000
+      containers:
+        - name: pocket-id
+          image: ghcr.io/pocket-id/pocket-id:v2.6.2
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 1411
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: pocket-id-config
+            - secretRef:
+                name: pocket-id-bootstrap
+          volumeMounts:
+            - name: data
+              mountPath: /app/data
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            periodSeconds: 10
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            failureThreshold: 30
+            periodSeconds: 5
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi

--- a/terraform/pocket-id.tf
+++ b/terraform/pocket-id.tf
@@ -1,0 +1,35 @@
+# Pocket ID bootstrap secret
+#
+# ENCRYPTION_KEY is set ONCE at first deploy and must NEVER change
+# (rotating it would render existing encrypted-at-rest data unrecoverable).
+# Terraform owns it via random_password so the state is the source of
+# truth across rebuilds and the operator never has to touch it.
+#
+# The pocket-id ArgoCD Application has CreateNamespace=true so it can
+# create the namespace if Terraform hasn't yet. The kubernetes_namespace
+# resource here is just to make TF apply idempotent regardless of
+# ordering.
+
+resource "kubernetes_namespace" "pocket_id" {
+  metadata {
+    name = "pocket-id"
+  }
+}
+
+resource "random_password" "pocket_id_encryption_key" {
+  length  = 32
+  special = false
+}
+
+# Pocket ID reads its config from env vars; the StatefulSet wires this
+# Secret via envFrom so each key becomes its own env var.
+resource "kubernetes_secret" "pocket_id_bootstrap" {
+  metadata {
+    name      = "pocket-id-bootstrap"
+    namespace = kubernetes_namespace.pocket_id.metadata[0].name
+  }
+
+  data = {
+    ENCRYPTION_KEY = random_password.pocket_id_encryption_key.result
+  }
+}


### PR DESCRIPTION
## Summary

Fourth merged piece of the IAP auth-stack rollout (after #64/#65/#66/#68). Adds **Pocket ID** as the OIDC IdP for all downstream apps. Hand-built Kustomize manifests rather than a community Helm chart, mirroring the kargo-projects single-source pattern.

Hosted at `id.andyleap.dev` via a new HTTPRoute attached to the existing `traefik-gateway/websecure` listener (wildcard cert already in place).

## What's in this PR

| Path | What |
|---|---|
| `cluster/pocket-id.yaml` | ArgoCD Application, single Kustomize source on the `pocket-id/` dir |
| `pocket-id/kustomization.yaml` | resources + `images:` block (Kargo bumps `newTag` per release) |
| `pocket-id/configmap.yaml` | env vars: APP_URL, HOST, PORT, TRUST_PROXY, file backend, etc. |
| `pocket-id/statefulset.yaml` | 1 replica, 1Gi PVC at `/app/data`, drops all caps, runs non-root |
| `pocket-id/service.yaml` | ClusterIP :80 -> container :1411 |
| `pocket-id/httproute.yaml` | hostname `id.andyleap.dev` -> Service `pocket-id:80` |
| `terraform/pocket-id.tf` | namespace + Secret with a `random_password` ENCRYPTION_KEY |
| `kargo-projects/pocket-id/` | Project/Warehouse/Stage for image-tag promotion |

Also adds `pocket-id` to `cluster/kustomization.yaml` and `kargo-projects/kustomization.yaml`.

## Why a random_password TF secret instead of a values literal

The ENCRYPTION_KEY encrypts data at rest in Pocket ID's SQLite DB. It must be set once and never rotated (rotating it would orphan all encrypted data). Using `random_password` keeps the key out of git, stable across rebuilds (TF state is the source of truth), and doesn't require any operator input. Matches the existing kargo-admin-credentials pattern in `terraform/kargo.tf`.

## Manual steps after merge

1. Approve + apply the OpenTofu plan that this PR triggers. After apply, `kubectl -n pocket-id get secret pocket-id-bootstrap` should list `ENCRYPTION_KEY`. **Without this, the StatefulSet will be stuck Pending on the missing Secret.**
2. Wait for `kargo-pocket-id:main` to promote (or trigger manually).
3. Visit `https://id.andyleap.dev` and complete first-run setup: register the admin passkey.
4. In the Pocket ID admin UI, create an OIDC client for oauth2-proxy:
   - Name: `oauth2-proxy`
   - Callback URL: `https://auth.andyleap.dev/oauth2/callback`
   - Save client ID + client secret — these feed into PR 5 (oauth2-proxy + TF bootstrap).
5. Decide claim conventions before downstream apps onboard: identity = `sub`, display = `name` (per rollout plan resolved decisions).

## Test plan

- [ ] OpenTofu plan posted and reviewed.
- [ ] Kustomize render (`kubectl kustomize pocket-id/`) is sensible — already verified locally.
- [ ] After TF apply + Kargo promotion: StatefulSet ready, `https://id.andyleap.dev` serves with the wildcard cert.
- [ ] First-run page loads; passkey registration works.
- [ ] Pocket ID's `/.well-known/openid-configuration` is reachable at `https://id.andyleap.dev/.well-known/openid-configuration`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)