### PR TITLE
Wire ArgoCD to Pocket ID via OIDC, drop local admin

### DIFF
--- a/.github/workflows/opentofu.yml
+++ b/.github/workflows/opentofu.yml
@@ -84,6 +84,13 @@ jobs:
         echo "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID" >> $GITHUB_ENV
         echo "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY" >> $GITHUB_ENV
 
+    - name: Configure Pocket ID provider env
+      env:
+        POCKETID_API_TOKEN: ${{ secrets.POCKETID_API_TOKEN }}
+      run: |
+        echo "POCKETID_BASE_URL=https://id.andyleap.dev" >> $GITHUB_ENV
+        echo "POCKETID_API_TOKEN=$POCKETID_API_TOKEN" >> $GITHUB_ENV
+
     - name: Install s3cmd
       run: uv tool install s3cmd
 
@@ -250,6 +257,13 @@ jobs:
       run: |
         echo "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID" >> $GITHUB_ENV
         echo "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY" >> $GITHUB_ENV
+
+    - name: Configure Pocket ID provider env
+      env:
+        POCKETID_API_TOKEN: ${{ secrets.POCKETID_API_TOKEN }}
+      run: |
+        echo "POCKETID_BASE_URL=https://id.andyleap.dev" >> $GITHUB_ENV
+        echo "POCKETID_API_TOKEN=$POCKETID_API_TOKEN" >> $GITHUB_ENV
 
     - name: Install s3cmd
       run: uv tool install s3cmd

--- a/argocd/values.yaml
+++ b/argocd/values.yaml
@@ -4,3 +4,36 @@
 configs:
   params:
     server.insecure: true
+
+  cm:
+    # Public URL of ArgoCD; required for OIDC redirect URLs.
+    url: https://argocd.andyleap.dev
+
+    # Disable local admin -- OIDC is the only auth path. Loss of OIDC
+    # is recoverable by reverting this flag via Kargo + ArgoCD config.
+    admin.enabled: "false"
+
+    # OIDC against Pocket ID. clientID + clientSecret are referenced
+    # from the kubernetes_secret managed by Terraform (argocd-oidc).
+    # Pocket ID emits the `groups` claim when the OIDC client requests
+    # the `groups` scope; argocd-admins membership flows through to
+    # the policy below.
+    oidc.config: |
+      name: Pocket ID
+      issuer: https://id.andyleap.dev
+      clientID: $argocd-oidc:clientID
+      clientSecret: $argocd-oidc:clientSecret
+      requestedScopes:
+        - openid
+        - profile
+        - email
+        - groups
+      requestedIDTokenClaims:
+        groups:
+          essential: true
+
+  rbac:
+    # Default deny -- only members of mapped groups have any access.
+    policy.default: ""
+    policy.csv: |
+      g, argocd-admins, role:admin

--- a/terraform/argocd-oidc.tf
+++ b/terraform/argocd-oidc.tf
@@ -1,0 +1,49 @@
+# ArgoCD OIDC client + RBAC group in Pocket ID, and the matching
+# kubernetes_secret that argocd-server reads via $<secret>:<key>
+# references in argocd-cm.
+#
+# Group-based RBAC: argocd-admins members get role:admin in ArgoCD.
+# Add yourself to the group manually via Pocket ID's UI -- the
+# provider has no data source for existing users and we don't want
+# to import the bootstrap-created passkey user into TF state.
+
+resource "pocketid_group" "argocd_admins" {
+  name          = "argocd-admins"
+  friendly_name = "ArgoCD Admins"
+}
+
+resource "pocketid_client" "argocd" {
+  name = "ArgoCD"
+
+  callback_urls = [
+    "https://argocd.andyleap.dev/auth/callback",
+    # CLI / PKCE flow callback (argocd login --sso)
+    "http://localhost:8085/auth/callback",
+  ]
+
+  logout_callback_urls = [
+    "https://argocd.andyleap.dev",
+  ]
+
+  is_public    = false
+  pkce_enabled = true
+  launch_url   = "https://argocd.andyleap.dev"
+}
+
+# argocd-server reads $argocd-oidc:<key> references in the argocd-cm
+# ConfigMap from this Secret.
+resource "kubernetes_secret" "argocd_oidc" {
+  metadata {
+    name      = "argocd-oidc"
+    namespace = "argocd"
+    # ArgoCD only follows references to Secrets carrying this label.
+    labels = {
+      "app.kubernetes.io/part-of" = "argocd"
+    }
+  }
+
+  data = {
+    clientID     = pocketid_client.argocd.client_id
+    clientSecret = pocketid_client.argocd.client_secret
+  }
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -37,6 +37,10 @@ terraform {
       source  = "loafoe/htpasswd"
       version = "~> 1.2"
     }
+    pocketid = {
+      source  = "trozz/pocketid"
+      version = "~> 0.1"
+    }
   }
 }
 

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -12,3 +12,7 @@ provider "github" {
     # Uses GITHUB_APP_ID, GITHUB_APP_INSTALLATION_ID, GITHUB_APP_PEM_FILE environment variables
   }
 }
+
+provider "pocketid" {
+  # Uses POCKETID_BASE_URL and POCKETID_API_TOKEN environment variables
+}


### PR DESCRIPTION
## Summary

First Category 2 onboarding: ArgoCD as a native OIDC client of Pocket ID. Local admin is disabled; OIDC is the only auth path.

The OIDC client + RBAC group in Pocket ID are managed declaratively via the [`trozz/pocketid`](https://registry.terraform.io/providers/trozz/pocketid/latest) provider, so future apps slot in by adding a few lines of TF rather than clicking through Pocket ID's UI.

## What's in this PR

| Path | What |
|---|---|
| `terraform/main.tf` | Register `trozz/pocketid ~> 0.1` provider |
| `terraform/providers.tf` | Empty `pocketid` provider block (env-driven config) |
| `terraform/argocd-oidc.tf` | `pocketid_group "argocd_admins"` + `pocketid_client "argocd"` + `kubernetes_secret "argocd-oidc"` (labelled so `argocd-server` will resolve `$argocd-oidc:<key>` refs from `argocd-cm`) |
| `argocd/values.yaml` | `oidc.config` for Pocket ID (issuer, requestedScopes incl. `groups`), `admin.enabled: "false"`, `rbac.policy.default: ""`, `rbac.policy.csv` maps `argocd-admins` → `role:admin` |
| `.github/workflows/opentofu.yml` | New "Configure Pocket ID provider env" step in both plan and apply jobs; exports `POCKETID_BASE_URL=https://id.andyleap.dev` + `POCKETID_API_TOKEN` (from a new repo secret) to `$GITHUB_ENV` so subsequent `tofu` runs pick them up |

## Manual setup required before this PR can apply

1. **Create the Pocket ID API token**: In the Pocket ID admin UI → Settings → API Keys, generate a new API key for your admin user.
2. **Add it as a repo secret**: `POCKETID_API_TOKEN` in this repo's Actions secrets.
3. **After `tofu apply` succeeds, add yourself to `argocd-admins`** in Pocket ID's UI. (The provider has no data source for existing users, so the bootstrap user `andy` isn't managed by TF; we don't want to import the passkey user into TF state. One-time manual click.)

## Why these RBAC choices

- **Group-based** (`g, argocd-admins, role:admin`): scales when you add a 2nd user — they get added to the Pocket ID group, no ArgoCD config change.
- **`policy.default: ""`** (default deny): any OIDC-authenticated user without group membership has zero ArgoCD access. Reduces blast radius if Pocket ID account gets phished.

## Test plan

- [ ] OpenTofu plan posted and reviewed; plan shows `pocketid_group`, `pocketid_client`, `kubernetes_secret` creation.
- [ ] After `tofu apply`: `kubectl -n argocd get secret argocd-oidc` lists `clientID` + `clientSecret` keys.
- [ ] After you add yourself to `argocd-admins` in Pocket ID: visit `https://argocd.andyleap.dev` → "LOG IN VIA POCKET ID" button appears → Pocket ID prompts for passkey → redirect lands you in ArgoCD with admin rights.
- [ ] Confirm local admin login is gone (the `admin` username field shouldn't accept your old password).
- [ ] Sanity: `argocd app list` from the UI still shows the existing applications (sync/health unchanged).

## Rollback

Flip `configs.cm.admin.enabled` back to `"true"` via Kargo + ArgoCD config, re-enable, sign in with the local admin you saved during initial setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)