### PR TITLE
Fix ArgoCD OIDC Secret: use .id for the OIDC client ID

### DIFF
--- a/terraform/argocd-oidc.tf
+++ b/terraform/argocd-oidc.tf
@@ -43,7 +43,9 @@ resource "kubernetes_secret" "argocd_oidc" {
   }
 
   data = {
-    clientID     = pocketid_client.argocd.client_id
+    # `.id` holds the auto-generated OIDC client identifier; `.client_id`
+    # only carries a value when set as an input on the resource.
+    clientID     = pocketid_client.argocd.id
     clientSecret = pocketid_client.argocd.client_secret
   }
 }


### PR DESCRIPTION
## Summary

One-line fix on top of #75. The trozz/pocketid resource has two confusingly-named attributes:

- `.client_id` — Optional **input**; only set when you pass a custom `client_id` on the resource.
- `.id` — Computed read-only; holds the actual OIDC client ID (auto-generated or user-supplied).

PR #75 used `.client_id`, which is `null` for us since we didn't set a custom ID. The kubernetes_secret silently dropped the empty key, so the `argocd-oidc` Secret only ended up with `clientSecret` and not `clientID`.

Verified post-#75 apply:

\`\`\`
kubectl -n argocd get secret argocd-oidc -o jsonpath='{.data}'
# clientSecret only, no clientID
\`\`\`

Without `clientID`, `argocd-server`'s `$argocd-oidc:clientID` substitution renders empty and the `/authorize` redirect to Pocket ID would fail.

## Test plan

- [ ] OpenTofu plan shows the in-place update of `kubernetes_secret.argocd_oidc` to add the `clientID` data key.
- [ ] After apply: `kubectl -n argocd get secret argocd-oidc -o jsonpath='{.data}'` lists both `clientID` and `clientSecret`.
- [ ] ArgoCD login via Pocket ID works end-to-end (after you add yourself to the `argocd-admins` group in Pocket ID's UI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)