### PR TITLE
ArgoCD OIDC: enable PKCE on the web login flow

### DIFF
--- a/argocd/values.yaml
+++ b/argocd/values.yaml
@@ -23,6 +23,11 @@ configs:
       issuer: https://id.andyleap.dev
       clientID: $argocd-oidc:clientID
       clientSecret: $argocd-oidc:clientSecret
+      # Pocket ID's client is created with pkce_enabled=true (enforces
+      # PKCE on every token exchange). ArgoCD's web login flow doesn't
+      # send a code_verifier by default; this flag turns on PKCE for
+      # the web flow too so the verifier matches.
+      enablePKCEAuthentication: true
       requestedScopes:
         - openid
         - profile


### PR DESCRIPTION
## Summary

Adds `enablePKCEAuthentication: true` to ArgoCD's `oidc.config` so the web login flow generates and sends a PKCE `code_verifier`. Without this, Pocket ID (which we created with `pkce_enabled = true`, enforcing PKCE) rejects the token exchange with `oauth2: Invalid code verifier`.

User-reported symptom from #76: passkey + approve in Pocket ID succeeded, then ArgoCD got the auth code back, and the `/token` POST failed.

## Test plan

- [ ] After Kargo promotes and argocd-server restarts: `https://argocd.andyleap.dev` → LOG IN VIA POCKET ID → passkey → land in ArgoCD UI as admin (once `andy` is a member of `argocd-admins` in Pocket ID).

🤖 Generated with [Claude Code](https://claude.com/claude-code)