### PR TITLE
Wire Kargo to Pocket ID via OIDC (PKCE-only), drop local admin

### DIFF
--- a/kargo/values.yaml
+++ b/kargo/values.yaml
@@ -6,9 +6,12 @@ crds:
   keep: true
 
 api:
+  # Local admin disabled -- OIDC is the only auth path.
+  # The kargo-api Secret stays for ADMIN_ACCOUNT_TOKEN_SIGNING_KEY,
+  # which the API server uses to sign session JWTs even for OIDC
+  # users. Cleanup of the now-unused PASSWORD_HASH is a follow-up.
   adminAccount:
-    enabled: true
-  # passwordHash + tokenSigningKey come from the Terraform-managed Secret.
+    enabled: false
   secret:
     name: kargo-api
   host: kargo.andyleap.dev
@@ -20,6 +23,22 @@ api:
   # Kargo API serves plain HTTP on port 80 inside the cluster.
   tls:
     enabled: false
+
+  # OIDC against Pocket ID. PKCE-only (no client_secret), so the
+  # client_id is hardcoded here -- it's an identifier, not a secret.
+  # The matching pocketid_client + pocketid_group are in
+  # terraform/kargo-oidc.tf.
+  oidc:
+    enabled: true
+    issuerURL: https://id.andyleap.dev
+    clientID: kargo
+    usernameClaim: sub
+    additionalScopes:
+      - groups
+    admins:
+      claims:
+        groups:
+          - kargo-admins
 
 webhooksServer:
   tls:

--- a/terraform/kargo-oidc.tf
+++ b/terraform/kargo-oidc.tf
@@ -1,0 +1,39 @@
+# Kargo OIDC client + RBAC group in Pocket ID.
+#
+# Unlike ArgoCD, Kargo's OIDC implementation is PKCE-only and doesn't
+# use a client_secret -- so this file does NOT create a kubernetes_secret.
+# kargo/values.yaml references the client_id directly. We pin the
+# client_id input to a stable string so the value can be hardcoded in
+# the chart values without the chicken-and-egg of "TF generates an ID
+# that values.yaml needs to know at apply time."
+#
+# Group-based RBAC: members of `kargo-admins` get Kargo admin privileges
+# via the chart's api.oidc.admins.claims.groups mapping (no K8s
+# ClusterRoleBinding plumbing required -- Kargo does its own RBAC
+# internally from the OIDC claims).
+
+resource "pocketid_group" "kargo_admins" {
+  name          = "kargo-admins"
+  friendly_name = "Kargo Admins"
+}
+
+resource "pocketid_client" "kargo" {
+  name      = "Kargo"
+  client_id = "kargo"
+
+  # Kargo's UI sets redirect_uri = window.location.origin + pathname at
+  # login-click time, which is typically /login. Register both /login
+  # and / so deep-link users coming through the auth gate still match.
+  callback_urls = [
+    "https://kargo.andyleap.dev/login",
+    "https://kargo.andyleap.dev/",
+  ]
+
+  logout_callback_urls = [
+    "https://kargo.andyleap.dev/login",
+  ]
+
+  is_public    = true
+  pkce_enabled = true
+  launch_url   = "https://kargo.andyleap.dev"
+}


### PR DESCRIPTION
## Summary

Second Category 2 onboarding, mirroring #75/#76/#77 for Kargo. Kargo's OIDC is simpler than ArgoCD's:

- **PKCE-only, no client_secret.** Pocket ID client is `is_public: true`; no Kubernetes Secret needed.
- **Built-in role mappings** via `api.oidc.admins.claims.groups` — no K8s ClusterRoleBinding plumbing.

The `client_id` is pinned to a stable string (`"kargo"`) so `kargo/values.yaml` can hardcode it without TF needing to write back into git on apply.

## What's in this PR

| Path | What |
|---|---|
| `terraform/kargo-oidc.tf` | `pocketid_group "kargo_admins"` + `pocketid_client "kargo"` (is_public, pkce_enabled, custom client_id = "kargo"). Callback URLs `/login` and `/` (Kargo's UI sets `redirect_uri = window.location.origin + pathname` at click time). |
| `kargo/values.yaml` | `api.adminAccount.enabled: false` (OIDC-only); `api.oidc` block: enabled, issuerURL, clientID="kargo", usernameClaim="sub", additionalScopes [groups], `admins.claims.groups: [kargo-admins]`. |

The `kargo-api` Secret (Terraform-managed) stays — it still carries `ADMIN_ACCOUNT_TOKEN_SIGNING_KEY` which the API server uses to sign session JWTs even for OIDC users. Cleanup of the now-unused bcrypt `PASSWORD_HASH` is a separate follow-up.

## Manual setup after merge

1. **Approve the OpenTofu plan + apply** — creates the `kargo-admins` group in Pocket ID.
2. **Add yourself to `kargo-admins`** via Pocket ID's UI (one-time, same pattern as `argocd-admins`).
3. After Kargo rolls out: `https://kargo.andyleap.dev/login` → LOG IN VIA POCKET ID → passkey → admin.

## Test plan

- [ ] OpenTofu plan shows `pocketid_group.kargo_admins` + `pocketid_client.kargo` creation.
- [ ] After apply + Kargo promotion: `kargo-api` Deployment env shows `OIDC_ENABLED=true` and the issuer/clientID values.
- [ ] After you add yourself to `kargo-admins`: passkey login lands you in Kargo with admin perms.
- [ ] Local admin login form is gone from the Kargo login page.

## Rollback

Flip `adminAccount.enabled` back to `true` via Kargo + ArgoCD config. The bcrypt password hash + token signing key are still in the `kargo-api` Secret (TF resources unchanged), so the form works again immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)