### PR TITLE
Kargo OIDC: inject real client_id via Secret + envFrom override

### DIFF
--- a/kargo/values.yaml
+++ b/kargo/values.yaml
@@ -24,14 +24,19 @@ api:
   tls:
     enabled: false
 
-  # OIDC against Pocket ID. PKCE-only (no client_secret), so the
-  # client_id is hardcoded here -- it's an identifier, not a secret.
-  # The matching pocketid_client + pocketid_group are in
-  # terraform/kargo-oidc.tf.
+  # OIDC against Pocket ID. PKCE-only (no client_secret).
+  #
+  # clientID is a placeholder here: Pocket ID auto-generates a UUID
+  # for the OIDC client (the trozz/pocketid provider can't pin a
+  # custom id today), and the real value lives in the TF-managed
+  # kargo-oidc Secret which we mount via api.envFrom below.
+  # api.envFrom is concatenated AFTER the chart's built-in
+  # configmap/secret envFroms, so OIDC_CLIENT_ID from the Secret
+  # wins the pod env merge.
   oidc:
     enabled: true
     issuerURL: https://id.andyleap.dev
-    clientID: kargo
+    clientID: overridden-by-kargo-oidc-secret
     usernameClaim: sub
     additionalScopes:
       - groups
@@ -39,6 +44,10 @@ api:
       claims:
         groups:
           - kargo-admins
+
+  envFrom:
+    - secretRef:
+        name: kargo-oidc
 
 webhooksServer:
   tls:

--- a/terraform/kargo-oidc.tf
+++ b/terraform/kargo-oidc.tf
@@ -1,16 +1,22 @@
-# Kargo OIDC client + RBAC group in Pocket ID.
+# Kargo OIDC client + RBAC group in Pocket ID, plus the kargo-oidc
+# Secret that threads Pocket ID's auto-generated client ID into the
+# Kargo API Deployment.
 #
-# Unlike ArgoCD, Kargo's OIDC implementation is PKCE-only and doesn't
-# use a client_secret -- so this file does NOT create a kubernetes_secret.
-# kargo/values.yaml references the client_id directly. We pin the
-# client_id input to a stable string so the value can be hardcoded in
-# the chart values without the chicken-and-egg of "TF generates an ID
-# that values.yaml needs to know at apply time."
+# Kargo's OIDC is PKCE-only -- no client_secret to manage. We'd
+# normally pin a stable custom client_id ("kargo") so values.yaml
+# could hardcode it, but the trozz/pocketid provider sends the
+# custom field under JSON `clientId` while Pocket ID's API expects
+# `id`, so the custom value is silently ignored and Pocket ID
+# auto-generates a UUID instead. To avoid hardcoding that UUID in
+# values.yaml, we write it into a Secret that the chart mounts via
+# api.envFrom; pod env merging makes the Secret's OIDC_CLIENT_ID
+# override the placeholder the chart emits into kargo-api's
+# ConfigMap.
 #
-# Group-based RBAC: members of `kargo-admins` get Kargo admin privileges
-# via the chart's api.oidc.admins.claims.groups mapping (no K8s
-# ClusterRoleBinding plumbing required -- Kargo does its own RBAC
-# internally from the OIDC claims).
+# Group-based RBAC: members of `kargo-admins` get Kargo admin
+# privileges via the chart's api.oidc.admins.claims.groups mapping
+# (no K8s ClusterRoleBinding plumbing required -- Kargo does its
+# own RBAC internally from the OIDC claims).
 
 resource "pocketid_group" "kargo_admins" {
   name          = "kargo-admins"

--- a/terraform/kargo-oidc.tf
+++ b/terraform/kargo-oidc.tf
@@ -18,8 +18,13 @@ resource "pocketid_group" "kargo_admins" {
 }
 
 resource "pocketid_client" "kargo" {
-  name      = "Kargo"
-  client_id = "kargo"
+  name = "Kargo"
+
+  # NB: do not set `client_id` here -- the trozz/pocketid provider
+  # sends it as JSON `clientId`, but Pocket ID's API expects `id`,
+  # so the custom value is silently ignored and Pocket ID
+  # auto-generates a UUID instead. The auto-generated value is
+  # exposed via `.id` and threaded into the Secret below.
 
   # Kargo's UI sets redirect_uri = window.location.origin + pathname at
   # login-click time, which is typically /login. Register both /login
@@ -36,4 +41,21 @@ resource "pocketid_client" "kargo" {
   is_public    = true
   pkce_enabled = true
   launch_url   = "https://kargo.andyleap.dev"
+}
+
+# Override the OIDC_CLIENT_ID env var that the chart emits into the
+# kargo-api ConfigMap. Kargo's chart concatenates api.envFrom AFTER
+# its built-in configmap/secret entries, and pod env merging makes
+# the later source win on key collisions -- so mounting this Secret
+# via api.envFrom in kargo/values.yaml swaps the placeholder for
+# Pocket ID's actual auto-generated client id.
+resource "kubernetes_secret" "kargo_oidc" {
+  metadata {
+    name      = "kargo-oidc"
+    namespace = "kargo"
+  }
+
+  data = {
+    OIDC_CLIENT_ID = pocketid_client.kargo.id
+  }
 }


### PR DESCRIPTION
## Summary

Workaround for the trozz/pocketid provider bug discovered while testing #79's apply.

The provider sends a custom `client_id` to Pocket ID's API under JSON key `"clientId"`, but Pocket ID's create-client DTO expects `"id"`. So the field is silently ignored and Pocket ID auto-generates a UUID. PR #79's `client_id = "kargo"` never landed; the actual OIDC client ID is a UUID. Kargo's `/authorize` redirect with `client_id=kargo` got "Record not found" from Pocket ID.

This PR fixes it without filing anything upstream and without hardcoding a UUID in `values.yaml`:

- `terraform/kargo-oidc.tf`: drops `client_id = "kargo"` (which was being ignored anyway). Adds a `kubernetes_secret "kargo-oidc"` with `OIDC_CLIENT_ID = pocketid_client.kargo.id` — TF threads the auto-generated UUID into the cluster automatically.
- `kargo/values.yaml`: sets `api.oidc.clientID` to a placeholder string (the chart's ConfigMap still emits `OIDC_ENABLED=true`, etc., cleanly) and adds `api.envFrom` mounting the new Secret. The Kargo chart concatenates `api.envFrom` AFTER its built-in configmap/secret envFroms — pod env merging makes the later source win — so `OIDC_CLIENT_ID` from the Secret overrides the placeholder.

No UUID is hardcoded anywhere. If TF ever re-creates the OIDC client and Pocket ID issues a fresh UUID, the Secret rotates automatically and the pod restart picks it up.

## Test plan

- [ ] OpenTofu plan: in-place update of `kubernetes_secret.kargo_oidc` (new resource); `pocketid_client.kargo` shows `client_id` going from `"kargo"` → null (it was ineffective anyway, so no behavior change in Pocket ID).
- [ ] After apply + Kargo promotion:
  - `kubectl -n kargo get secret kargo-oidc -o jsonpath='{.data.OIDC_CLIENT_ID}' | base64 -d` matches the UUID shown for the Kargo client in Pocket ID's admin UI.
  - `kubectl -n kargo exec deploy/kargo-api -- printenv OIDC_CLIENT_ID` prints that same UUID (not the placeholder string).
- [ ] `https://kargo.andyleap.dev/login` → LOG IN VIA POCKET ID → passkey → admin (with the `kargo-admins` group membership step from #79).

## Re: upstream

I won't post about the provider bug upstream without explicit approval. The diagnosis stays in the commit message + comments here for future-us.

🤖 Generated with [Claude Code](https://claude.com/claude-code)