### PR TITLE
Enable ArgoCD server-side diff (silence apiserver-defaulted drift)

### DIFF
--- a/argocd/values.yaml
+++ b/argocd/values.yaml
@@ -6,6 +6,16 @@ configs:
     server.insecure: true
 
   cm:
+    # Server-side diff: ArgoCD asks the apiserver for a dry-run
+    # apply and compares the predicted result to live state, so
+    # apiserver-defaulted fields (StatefulSet's podManagementPolicy,
+    # persistentVolumeClaimRetentionPolicy, etc.) stop showing up
+    # as drift across every Application. Respects Kubernetes's
+    # field ownership model rather than comparing raw manifests
+    # byte-for-byte.
+    resource.compareoptions: |
+      serverSideDiff: true
+
     # Public URL of ArgoCD; required for OIDC redirect URLs.
     url: https://argocd.andyleap.dev
 


### PR DESCRIPTION
## Summary

Add `resource.compareoptions: serverSideDiff: true` to `argocd-cm` via the chart values. ArgoCD asks the apiserver for a dry-run apply and compares the predicted result (which includes apiserver defaults) to live state, instead of comparing raw manifests byte-for-byte.

## Why

The `pocket-id` Application has been showing `OutOfSync` because the live StatefulSet has two apiserver-defaulted fields that the manifest in git doesn't carry: `podManagementPolicy: OrderedReady` and `persistentVolumeClaimRetentionPolicy: {whenDeleted: Retain, whenScaled: Retain}`. ArgoCD's default client-side diff has no awareness of K8s field defaulting and sees these as drift even though no one is managing them and ArgoCD wouldn't change them.

Hardcoding the defaults in the StatefulSet manifest would silence the symptom but re-encodes K8s's own defaults in our git tree — wrong abstraction, breaks if K8s ever changes defaults. Server-side diff is the documented K8s-aware solution and is supported as stable since ArgoCD v2.10 (we're on v3.4.2).

## Test plan

- [ ] After Kargo promotes + argocd-server reloads `argocd-cm`:
  - `kubectl -n argocd get cm argocd-cm -o jsonpath='{.data.resource\.compareoptions}'` includes `serverSideDiff: true`.
  - `pocket-id` Application goes `sync=Synced` (was `OutOfSync`).
  - All other Applications stay Synced (no regression — server-side diff is at worst more accurate, never less).

🤖 Generated with [Claude Code](https://claude.com/claude-code)