### PR TITLE
Drop maxUnavailable from pocket-id StatefulSet update strategy

### DIFF
--- a/pocket-id/statefulset.yaml
+++ b/pocket-id/statefulset.yaml
@@ -8,13 +8,11 @@ spec:
   serviceName: pocket-id
   replicas: 1
   revisionHistoryLimit: 1
-  # Litestream requires a single writer at a time; maxUnavailable:100%
-  # ensures the old pod exits before the new one starts.
-  updateStrategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 100%
-      partition: 0
+  # Default RollingUpdate strategy is fine: with replicas: 1 the
+  # rolling update takes the single pod down before creating the new
+  # one (sequential by ordinal), which preserves Litestream's
+  # single-writer guarantee. The maxUnavailable knob was gated behind
+  # a feature flag LKE doesn't expose and was redundant anyway.
   selector:
     matchLabels:
       app.kubernetes.io/name: pocket-id


### PR DESCRIPTION
## Summary

Remove `updateStrategy.rollingUpdate.maxUnavailable: 100%` from the pocket-id StatefulSet. The setting required the `MaxUnavailableStatefulSet` feature flag that LKE doesn't expose, and was redundant: with `replicas: 1`, the default RollingUpdate strategy already takes the single pod down before creating its replacement, preserving Litestream's single-writer guarantee.

This was likely also a source of phantom drift in ArgoCD's diff (the apiserver was silently dropping the field, leaving manifest != live). PR #81's server-side diff should already cover that class of bug, but cleaning up the stale knob is the right thing regardless.

## Test plan

- [ ] After Kargo promotes: `kubectl -n pocket-id get sts pocket-id -o yaml | grep -A4 updateStrategy` shows the default (`type: RollingUpdate`, no `maxUnavailable`).
- [ ] Pocket ID still rolls cleanly when its image bumps (Litestream sidecar terminates first, single-writer preserved).
- [ ] ArgoCD pocket-id App stays Synced/Healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)