### PR TITLE
Wire GitHub webhook from this repo to Kargo (kill 5-min poll lag)

### DIFF
--- a/kargo/extras/clusterconfig.yaml
+++ b/kargo/extras/clusterconfig.yaml
@@ -1,0 +1,21 @@
+# Single cluster-scoped GitHub webhook receiver. Every Warehouse in
+# every project subscribes to the same cluster repo, so one receiver
+# fans out to all of them; a per-ProjectConfig receiver would mean N
+# separate webhook registrations in GitHub.
+#
+# Kargo looks up the referenced Secret in the namespace named by
+# global.systemResources.namespace (default "kargo-system-resources",
+# auto-created by the chart). The Secret itself is provisioned by
+# Terraform (terraform/kargo-webhook.tf), which also computes the
+# matching path -- sha256("" + receiverName + secret) -- and registers
+# the GitHub webhook against it.
+apiVersion: kargo.akuity.io/v1alpha1
+kind: ClusterConfig
+metadata:
+  name: cluster
+spec:
+  webhookReceivers:
+    - name: github-cluster-repo
+      github:
+        secretRef:
+          name: kargo-github-webhook

--- a/kargo/extras/httproute-webhooks.yaml
+++ b/kargo/extras/httproute-webhooks.yaml
@@ -1,0 +1,25 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: kargo-webhooks
+  namespace: kargo
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: traefik-gateway
+      namespace: traefik
+      sectionName: websecure
+  hostnames:
+    - kargo-webhooks.andyleap.dev
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - group: ""
+          kind: Service
+          name: kargo-external-webhooks-server
+          port: 80
+          weight: 1

--- a/kargo/extras/kustomization.yaml
+++ b/kargo/extras/kustomization.yaml
@@ -1,8 +1,13 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: kargo
+# No top-level `namespace:` -- ClusterConfig is cluster-scoped and
+# kustomize cannot infer scope for CRDs, so it would otherwise inject
+# `metadata.namespace: kargo` and the API server would reject it.
+# All namespaced resources here declare their namespace explicitly.
 
 resources:
   - global-credentials-rbac.yaml
   - httproute.yaml
+  - httproute-webhooks.yaml
+  - clusterconfig.yaml

--- a/kargo/values.yaml
+++ b/kargo/values.yaml
@@ -53,6 +53,17 @@ webhooksServer:
   tls:
     selfSignedCert: true
 
+# Public webhook-receiver endpoint (separate hostname from the API).
+# Traefik terminates TLS at the edge via the kargo-webhooks HTTPRoute;
+# the pod serves plain HTTP and `terminatedUpstream: true` tells Kargo
+# to still publish https:// URLs in ClusterConfig/ProjectConfig status
+# so GitHub gets a real TLS URL to POST to.
+externalWebhooksServer:
+  host: kargo-webhooks.andyleap.dev
+  tls:
+    enabled: false
+    terminatedUpstream: true
+
 controller:
   argocd:
     integrationEnabled: true

--- a/terraform/kargo-webhook.tf
+++ b/terraform/kargo-webhook.tf
@@ -1,0 +1,66 @@
+# Push notification from this repo to Kargo's external webhook receiver,
+# so master pushes trigger affected Warehouses within seconds instead of
+# waiting for the next ~5 min poll.
+#
+# A single cluster-scoped ClusterConfig.webhookReceivers entry (see
+# kargo/extras/clusterconfig.yaml) handles every Warehouse in every
+# project; we register one GitHub webhook for it here.
+#
+# The receiver's URL path is sha256(project + receiverName + secret).
+# For ClusterConfig receivers project is "", so it reduces to
+# sha256(receiverName + secret). Source:
+#   https://github.com/akuity/kargo/blob/main/pkg/webhook/external/receiver.go
+#   ("buildWebhookPath") -- carries a "do not change" warning, so this
+# precomputation is stable.
+
+locals {
+  kargo_github_receiver_name = "github-cluster-repo"
+  kargo_webhook_host         = "kargo-webhooks.andyleap.dev"
+  kargo_github_webhook_path = format(
+    "/github/%s",
+    sha256("${local.kargo_github_receiver_name}${random_password.kargo_github_webhook.result}"),
+  )
+  kargo_github_webhook_url = "https://${local.kargo_webhook_host}${local.kargo_github_webhook_path}"
+}
+
+resource "random_password" "kargo_github_webhook" {
+  length  = 32
+  special = false
+}
+
+# Lives in the system-resources namespace because the receiver is
+# defined on ClusterConfig (cluster-scoped) and Kargo looks for its
+# Secrets in `global.systemResources.namespace`. The chart auto-creates
+# that namespace.
+resource "kubernetes_secret" "kargo_github_webhook" {
+  metadata {
+    name      = "kargo-github-webhook"
+    namespace = "kargo-system-resources"
+    labels = {
+      "kargo.akuity.io/cred-type" = "generic"
+    }
+  }
+
+  data = {
+    secret = random_password.kargo_github_webhook.result
+  }
+}
+
+resource "github_repository_webhook" "kargo" {
+  repository = data.github_repository.repo.name
+  events     = ["push"]
+  active     = true
+
+  configuration {
+    url          = local.kargo_github_webhook_url
+    content_type = "json"
+    secret       = random_password.kargo_github_webhook.result
+    insecure_ssl = false
+  }
+}
+
+output "kargo_github_webhook_url" {
+  value       = local.kargo_github_webhook_url
+  sensitive   = true
+  description = "Kargo external-webhooks-server URL for this repo's GitHub webhook. The path embeds sha256(receiverName + secret), so treat the URL itself as sensitive."
+}


### PR DESCRIPTION
Closes #82.

## Summary
- One cluster-scoped `ClusterConfig.webhookReceivers` entry handles every project at once — all Warehouses subscribe to this repo, so cluster scope means one GitHub webhook registration instead of N per-`ProjectConfig`.
- New `kargo-webhooks.andyleap.dev` HTTPRoute fronts `kargo-external-webhooks-server`; pod serves plain HTTP, Traefik terminates TLS (`tls.terminatedUpstream: true` keeps Kargo publishing `https://` URLs in status). Existing `*.andyleap.dev` wildcard cert covers the new hostname.
- Terraform generates the shared secret, materializes it as a `Secret` in `kargo-system-resources` (the chart-managed default for cluster-scoped Secret refs), precomputes the receiver path — `sha256("" + receiverName + secret)` matches Kargo's `buildWebhookPath` for cluster-scoped receivers — and registers the `github_repository_webhook` with `events=["push"]`, `content_type=json`. Polling stays on as the safety net per the issue's out-of-scope note.

## Test plan
- [ ] `tofu plan` shows: 1 `random_password`, 1 `kubernetes_secret` (in `kargo-system-resources`), 1 `github_repository_webhook` — no other drift
- [ ] After apply, GitHub repo Settings → Webhooks shows the receiver with a green check on the "ping" delivery
- [ ] `kubectl get clusterconfig cluster -o jsonpath='{.status.webhookReceivers[0].url}'` matches the URL registered in GitHub
- [ ] Merge a no-op PR and confirm the affected Warehouse(s) refresh within seconds (`kubectl -n kargo-<project> get warehouse <name> -o jsonpath='{.status.lastHandledRefresh}'`) instead of waiting for the next poll
- [ ] `kargo-webhooks.andyleap.dev` serves a Let's Encrypt cert (no browser warning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)