### PR TITLE
Add viewer-tier OIDC groups for ArgoCD and Kargo

### DIFF
--- a/argocd/values.yaml
+++ b/argocd/values.yaml
@@ -26,8 +26,8 @@ configs:
     # OIDC against Pocket ID. clientID + clientSecret are referenced
     # from the kubernetes_secret managed by Terraform (argocd-oidc).
     # Pocket ID emits the `groups` claim when the OIDC client requests
-    # the `groups` scope; argocd-admins membership flows through to
-    # the policy below.
+    # the `groups` scope; argocd-admins / argocd-viewers membership
+    # flows through to the policy below.
     oidc.config: |
       name: Pocket ID
       issuer: https://id.andyleap.dev
@@ -52,3 +52,4 @@ configs:
     policy.default: ""
     policy.csv: |
       g, argocd-admins, role:admin
+      g, argocd-viewers, role:readonly

--- a/kargo/values.yaml
+++ b/kargo/values.yaml
@@ -44,6 +44,15 @@ api:
       claims:
         groups:
           - kargo-admins
+    # Read-only access to all Kargo resources (Stages, Promotions,
+    # Warehouses, Freight, Projects). The chart renders a `kargo-viewer`
+    # ServiceAccount + ClusterRole/ClusterRoleBinding and stamps these
+    # claims onto the SA; Kargo's API server impersonates that SA for
+    # any user whose token matches a claim here.
+    viewers:
+      claims:
+        groups:
+          - kargo-viewers
 
   envFrom:
     - secretRef:

--- a/terraform/argocd-oidc.tf
+++ b/terraform/argocd-oidc.tf
@@ -2,14 +2,20 @@
 # kubernetes_secret that argocd-server reads via $<secret>:<key>
 # references in argocd-cm.
 #
-# Group-based RBAC: argocd-admins members get role:admin in ArgoCD.
-# Add yourself to the group manually via Pocket ID's UI -- the
-# provider has no data source for existing users and we don't want
-# to import the bootstrap-created passkey user into TF state.
+# Group-based RBAC: argocd-admins members get role:admin in ArgoCD,
+# argocd-viewers members get role:readonly. Add users to the groups
+# manually via Pocket ID's UI -- the provider has no data source for
+# existing users and we don't want to import the bootstrap-created
+# passkey user into TF state.
 
 resource "pocketid_group" "argocd_admins" {
   name          = "argocd-admins"
   friendly_name = "ArgoCD Admins"
+}
+
+resource "pocketid_group" "argocd_viewers" {
+  name          = "argocd-viewers"
+  friendly_name = "ArgoCD Viewers"
 }
 
 resource "pocketid_client" "argocd" {

--- a/terraform/kargo-oidc.tf
+++ b/terraform/kargo-oidc.tf
@@ -14,13 +14,21 @@
 # ConfigMap.
 #
 # Group-based RBAC: members of `kargo-admins` get Kargo admin
-# privileges via the chart's api.oidc.admins.claims.groups mapping
-# (no K8s ClusterRoleBinding plumbing required -- Kargo does its
-# own RBAC internally from the OIDC claims).
+# privileges, members of `kargo-viewers` get read-only access to all
+# Kargo resources. Both flow through the chart's api.oidc.admins /
+# api.oidc.viewers `claims.groups` mappings -- no K8s
+# ClusterRoleBinding plumbing required, Kargo does its own RBAC
+# internally from the OIDC claims and impersonates the matching
+# system-role ServiceAccount the chart renders for each tier.
 
 resource "pocketid_group" "kargo_admins" {
   name          = "kargo-admins"
   friendly_name = "Kargo Admins"
+}
+
+resource "pocketid_group" "kargo_viewers" {
+  name          = "kargo-viewers"
+  friendly_name = "Kargo Viewers"
 }
 
 resource "pocketid_client" "kargo" {


### PR DESCRIPTION
## Summary
- Extend the admins-only OIDC RBAC pattern with a read-only viewer tier on both ArgoCD and Kargo, so trusted teammates can inspect deployment state without sync/promote/delete rights.
- **ArgoCD**: new `pocketid_group.argocd_viewers`; `g, argocd-viewers, role:readonly` mapped in `argocd/values.yaml` (built-in `role:readonly` covers `get` on all resources).
- **Kargo**: new `pocketid_group.kargo_viewers`; `api.oidc.viewers.claims.groups` populated in `kargo/values.yaml`. The akuity/kargo chart already renders a `kargo-viewer` ServiceAccount + ClusterRole/ClusterRoleBinding — we just bind the OIDC group claim to it.
- Default policy stays deny-all on both; viewer access is opt-in via Pocket ID group membership.

Closes #78.

## Manual step after apply
Pocket ID UI → add viewer users to the `argocd-viewers` and/or `kargo-viewers` groups (the provider has no user data source, same one-time pattern as `*-admins`).

## Test plan
- [ ] `tofu plan` shows only two new `pocketid_group` resources (`argocd_viewers`, `kargo_viewers`).
- [ ] After apply, both groups exist in Pocket ID.
- [ ] A user in `argocd-viewers` can list/view ArgoCD Applications but cannot sync/delete.
- [ ] A user in `kargo-viewers` can list Stages/Promotions/Warehouses/Freight across Projects but cannot promote or mutate Freight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)