### PR TITLE
Kargo: kargo-cluster owns cluster/; drop chart auto-bumps

### DIFF
--- a/cluster/kustomization.yaml
+++ b/cluster/kustomization.yaml
@@ -1,10 +1,8 @@
 # Explicit list of Application files rendered by the parent `cluster`
 # ArgoCD Application. Listing each Application here (instead of letting
-# ArgoCD enumerate the directory) means that retiring an app is a
-# matter of removing one line: ArgoCD prunes the Application even if
-# the deleted file lingers on the live branch (which can happen because
-# per-app Kargo Stages don't propagate deletions of their own
-# cluster/<app>.yaml file).
+# ArgoCD enumerate the directory) acts as an explicit Application
+# registry: retiring an app means removing one line here AND deleting
+# the corresponding file in the same PR.
 #
 # When adding or removing an app, update this list AND the per-app
 # files in the same PR.

--- a/kargo-projects/argocd/stage.yaml
+++ b/kargo-projects/argocd/stage.yaml
@@ -22,9 +22,9 @@ spec:
               - branch: live
                 create: true
                 path: ./out
-        # Sync this stage's owned slice from master to live, then apply the bump on top.
-        # Clear this stage's dir on live first so files removed from master
-        # don't linger.
+        # Sync this Stage's owned slice (argocd/) from master to live.
+        # Clear first so files removed on master don't linger.
+        # cluster/argocd.yaml is owned by the kargo-cluster Stage.
         - uses: git-clear
           # First promotion against a fresh live has no ./out/argocd — that's
           # expected; ignore the resulting "no such file or directory" error.
@@ -33,23 +33,13 @@ spec:
             path: ./out/argocd
         - uses: copy
           config:
-            inPath: ./src/cluster/argocd.yaml
-            outPath: ./out/cluster/argocd.yaml
-        - uses: copy
-          config:
             inPath: ./src/argocd
             outPath: ./out/argocd
-        - uses: yaml-update
-          config:
-            path: ./out/cluster/argocd.yaml
-            updates:
-              - key: spec.sources.0.targetRevision
-                value: ${{ chartFrom("https://argoproj.github.io/argo-helm", "argo-cd").Version }}
         - uses: git-commit
           config:
             path: ./out
             message: |
-              kargo: bump argocd to chart ${{ chartFrom("https://argoproj.github.io/argo-helm", "argo-cd").Version }}
+              kargo: sync argocd/ to live
         - uses: git-push
           config:
             path: ./out

--- a/kargo-projects/argocd/warehouse.yaml
+++ b/kargo-projects/argocd/warehouse.yaml
@@ -5,10 +5,8 @@ metadata:
   namespace: kargo-argocd
 spec:
   subscriptions:
-    - chart:
-        repoURL: https://argoproj.github.io/argo-helm
-        name: argo-cd
-        semverConstraint: ">=8.0.0 <10.0.0"
+    # Chart-version auto-bumps were dropped (see #71). Chart upgrades
+    # are landed as manual PRs that edit cluster/argocd.yaml directly.
     - git:
         repoURL: https://github.com/andyleap-cluster/cluster.git
         branch: master

--- a/kargo-projects/cert-manager-webhook-linode/stage.yaml
+++ b/kargo-projects/cert-manager-webhook-linode/stage.yaml
@@ -22,6 +22,10 @@ spec:
               - branch: live
                 create: true
                 path: ./out
+        # Sync this Stage's owned slice (cert-manager-webhook-linode/) from
+        # master to live. Clear first so files removed on master don't
+        # linger. cluster/cert-manager-webhook-linode.yaml is owned by the
+        # kargo-cluster Stage.
         - uses: git-clear
           # First promotion against a fresh live has no ./out/cert-manager-webhook-linode — that's
           # expected; ignore the resulting "no such file or directory" error.
@@ -30,18 +34,8 @@ spec:
             path: ./out/cert-manager-webhook-linode
         - uses: copy
           config:
-            inPath: ./src/cluster/cert-manager-webhook-linode.yaml
-            outPath: ./out/cluster/cert-manager-webhook-linode.yaml
-        - uses: copy
-          config:
             inPath: ./src/cert-manager-webhook-linode
             outPath: ./out/cert-manager-webhook-linode
-        - uses: yaml-update
-          config:
-            path: ./out/cluster/cert-manager-webhook-linode.yaml
-            updates:
-              - key: spec.sources.0.targetRevision
-                value: ${{ commitFrom("https://github.com/linode/cert-manager-webhook-linode.git").Tag }}
         - uses: yaml-update
           config:
             path: ./out/cert-manager-webhook-linode/values.yaml
@@ -52,7 +46,7 @@ spec:
           config:
             path: ./out
             message: |
-              kargo: bump cert-manager-webhook-linode to ${{ commitFrom("https://github.com/linode/cert-manager-webhook-linode.git").Tag }} / image ${{ imageFrom("docker.io/linode/cert-manager-webhook-linode").Tag }}
+              kargo: bump cert-manager-webhook-linode image to ${{ imageFrom("docker.io/linode/cert-manager-webhook-linode").Tag }}
         - uses: git-push
           config:
             path: ./out

--- a/kargo-projects/cert-manager-webhook-linode/warehouse.yaml
+++ b/kargo-projects/cert-manager-webhook-linode/warehouse.yaml
@@ -5,13 +5,10 @@ metadata:
   namespace: kargo-cert-manager-webhook-linode
 spec:
   subscriptions:
-    # The chart for this webhook is hosted in a git repo, not a chart registry,
-    # so we track the repo's git tags as the "chart version".
-    - git:
-        repoURL: https://github.com/linode/cert-manager-webhook-linode.git
-        commitSelectionStrategy: SemVer
-        semverConstraint: ">=0.3.0 <1.0.0"
-        strictSemvers: true
+    # Chart-version (git-tag) auto-bumps were dropped (see #71). Chart
+    # upgrades are landed as manual PRs that edit
+    # cluster/cert-manager-webhook-linode.yaml directly. Image bumps
+    # still drive automated promotions.
     - image:
         repoURL: docker.io/linode/cert-manager-webhook-linode
         imageSelectionStrategy: SemVer

--- a/kargo-projects/cert-manager/stage.yaml
+++ b/kargo-projects/cert-manager/stage.yaml
@@ -22,6 +22,9 @@ spec:
               - branch: live
                 create: true
                 path: ./out
+        # Sync this Stage's owned slice (cert-manager/) from master to live.
+        # Clear first so files removed on master don't linger.
+        # cluster/cert-manager.yaml is owned by the kargo-cluster Stage.
         - uses: git-clear
           # First promotion against a fresh live has no ./out/cert-manager — that's
           # expected; ignore the resulting "no such file or directory" error.
@@ -30,23 +33,13 @@ spec:
             path: ./out/cert-manager
         - uses: copy
           config:
-            inPath: ./src/cluster/cert-manager.yaml
-            outPath: ./out/cluster/cert-manager.yaml
-        - uses: copy
-          config:
             inPath: ./src/cert-manager
             outPath: ./out/cert-manager
-        - uses: yaml-update
-          config:
-            path: ./out/cluster/cert-manager.yaml
-            updates:
-              - key: spec.sources.0.targetRevision
-                value: ${{ chartFrom("https://charts.jetstack.io", "cert-manager").Version }}
         - uses: git-commit
           config:
             path: ./out
             message: |
-              kargo: bump cert-manager to chart ${{ chartFrom("https://charts.jetstack.io", "cert-manager").Version }}
+              kargo: sync cert-manager/ to live
         - uses: git-push
           config:
             path: ./out

--- a/kargo-projects/cert-manager/warehouse.yaml
+++ b/kargo-projects/cert-manager/warehouse.yaml
@@ -5,10 +5,8 @@ metadata:
   namespace: kargo-cert-manager
 spec:
   subscriptions:
-    - chart:
-        repoURL: https://charts.jetstack.io
-        name: cert-manager
-        semverConstraint: ">=1.16.0 <2.0.0"
+    # Chart-version auto-bumps were dropped (see #71). Chart upgrades
+    # are landed as manual PRs that edit cluster/cert-manager.yaml directly.
     - git:
         repoURL: https://github.com/andyleap-cluster/cluster.git
         branch: master

--- a/kargo-projects/cluster/stage.yaml
+++ b/kargo-projects/cluster/stage.yaml
@@ -22,22 +22,23 @@ spec:
               - branch: live
                 create: true
                 path: ./out
+        # This Stage owns the entire cluster/ dir on live. Clearing
+        # first and then copying the whole directory means file
+        # additions and removals on master both propagate cleanly —
+        # per-app Stages no longer write into cluster/.
+        - uses: git-clear
+          continueOnError: true
+          config:
+            path: ./out/cluster
         - uses: copy
           config:
-            inPath: ./src/cluster/cluster.yaml
-            outPath: ./out/cluster/cluster.yaml
-        # kustomization.yaml is what makes per-app retirements propagate
-        # to live: ArgoCD prunes Applications removed from the resources
-        # list even if the file lingers on live.
-        - uses: copy
-          config:
-            inPath: ./src/cluster/kustomization.yaml
-            outPath: ./out/cluster/kustomization.yaml
+            inPath: ./src/cluster
+            outPath: ./out/cluster
         - uses: git-commit
           config:
             path: ./out
             message: |
-              kargo: mirror cluster.yaml + kustomization.yaml to live
+              kargo: mirror cluster/ to live
         - uses: git-push
           config:
             path: ./out

--- a/kargo-projects/kargo-projects/stage.yaml
+++ b/kargo-projects/kargo-projects/stage.yaml
@@ -24,6 +24,7 @@ spec:
                 path: ./out
         # Mirror the kargo-projects/ directory (project, warehouse, stage,
         # projectconfig defs for every Kargo pipeline) from master to live.
+        # cluster/kargo-projects.yaml is owned by the kargo-cluster Stage.
         - uses: git-clear
           continueOnError: true
           config:
@@ -32,11 +33,6 @@ spec:
           config:
             inPath: ./src/kargo-projects
             outPath: ./out/kargo-projects
-        # Copy this pipeline's own ArgoCD App manifest so it ends up on live.
-        - uses: copy
-          config:
-            inPath: ./src/cluster/kargo-projects.yaml
-            outPath: ./out/cluster/kargo-projects.yaml
         - uses: git-commit
           config:
             path: ./out

--- a/kargo-projects/kargo/stage.yaml
+++ b/kargo-projects/kargo/stage.yaml
@@ -22,8 +22,9 @@ spec:
               - branch: live
                 create: true
                 path: ./out
-        # Clear the kargo helm values directory so removed files on master
-        # don't linger on live.
+        # Sync this Stage's owned slice (kargo/) from master to live.
+        # Clear first so files removed on master don't linger.
+        # cluster/kargo.yaml is owned by the kargo-cluster Stage.
         - uses: git-clear
           # First promotion against a fresh live has no ./out/kargo — that's
           # expected; ignore the resulting "no such file or directory" error.
@@ -34,26 +35,11 @@ spec:
           config:
             inPath: ./src/kargo
             outPath: ./out/kargo
-        # Copy this Stage's own ArgoCD App manifest. cluster/cluster.yaml
-        # is owned by the kargo-cluster pipeline; cluster/kargo-projects.yaml
-        # by kargo-kargo-projects.
-        - uses: copy
-          config:
-            inPath: ./src/cluster/kargo.yaml
-            outPath: ./out/cluster/kargo.yaml
-        # Bump the kargo chart targetRevision to whatever the warehouse
-        # discovered.
-        - uses: yaml-update
-          config:
-            path: ./out/cluster/kargo.yaml
-            updates:
-              - key: spec.sources.0.targetRevision
-                value: ${{ chartFrom("oci://ghcr.io/akuity/kargo-charts/kargo").Version }}
         - uses: git-commit
           config:
             path: ./out
             message: |
-              kargo: bump kargo to chart ${{ chartFrom("oci://ghcr.io/akuity/kargo-charts/kargo").Version }}
+              kargo: sync kargo/ to live
         - uses: git-push
           config:
             path: ./out

--- a/kargo-projects/kargo/warehouse.yaml
+++ b/kargo-projects/kargo/warehouse.yaml
@@ -5,9 +5,8 @@ metadata:
   namespace: kargo-kargo
 spec:
   subscriptions:
-    - chart:
-        repoURL: oci://ghcr.io/akuity/kargo-charts/kargo
-        semverConstraint: ">=1.0.0 <2.0.0"
+    # Chart-version auto-bumps were dropped (see #71). Chart upgrades
+    # are landed as manual PRs that edit cluster/kargo.yaml directly.
     - git:
         repoURL: https://github.com/andyleap-cluster/cluster.git
         branch: master

--- a/kargo-projects/pocket-id/stage.yaml
+++ b/kargo-projects/pocket-id/stage.yaml
@@ -22,16 +22,15 @@ spec:
               - branch: live
                 create: true
                 path: ./out
+        # Sync this Stage's owned slice (pocket-id/) from master to live.
+        # Clear first so files removed on master don't linger.
+        # cluster/pocket-id.yaml is owned by the kargo-cluster Stage.
         - uses: git-clear
           # First promotion against a fresh live has no ./out/pocket-id — that's
           # expected; ignore the resulting "no such file or directory" error.
           continueOnError: true
           config:
             path: ./out/pocket-id
-        - uses: copy
-          config:
-            inPath: ./src/cluster/pocket-id.yaml
-            outPath: ./out/cluster/pocket-id.yaml
         - uses: copy
           config:
             inPath: ./src/pocket-id

--- a/kargo-projects/traefik-crds/stage.yaml
+++ b/kargo-projects/traefik-crds/stage.yaml
@@ -22,6 +22,9 @@ spec:
               - branch: live
                 create: true
                 path: ./out
+        # Sync this Stage's owned slice (traefik-crds/) from master to live.
+        # Clear first so files removed on master don't linger.
+        # cluster/traefik-crds.yaml is owned by the kargo-cluster Stage.
         - uses: git-clear
           # First promotion against a fresh live has no ./out/traefik-crds — that's
           # expected; ignore the resulting "no such file or directory" error.
@@ -30,23 +33,13 @@ spec:
             path: ./out/traefik-crds
         - uses: copy
           config:
-            inPath: ./src/cluster/traefik-crds.yaml
-            outPath: ./out/cluster/traefik-crds.yaml
-        - uses: copy
-          config:
             inPath: ./src/traefik-crds
             outPath: ./out/traefik-crds
-        - uses: yaml-update
-          config:
-            path: ./out/cluster/traefik-crds.yaml
-            updates:
-              - key: spec.sources.0.targetRevision
-                value: ${{ chartFrom("https://traefik.github.io/charts", "traefik-crds").Version }}
         - uses: git-commit
           config:
             path: ./out
             message: |
-              kargo: bump traefik-crds to chart ${{ chartFrom("https://traefik.github.io/charts", "traefik-crds").Version }}
+              kargo: sync traefik-crds/ to live
         - uses: git-push
           config:
             path: ./out

--- a/kargo-projects/traefik-crds/warehouse.yaml
+++ b/kargo-projects/traefik-crds/warehouse.yaml
@@ -5,10 +5,8 @@ metadata:
   namespace: kargo-traefik-crds
 spec:
   subscriptions:
-    - chart:
-        repoURL: https://traefik.github.io/charts
-        name: traefik-crds
-        semverConstraint: ">=1.18.0 <2.0.0"
+    # Chart-version auto-bumps were dropped (see #71). Chart upgrades
+    # are landed as manual PRs that edit cluster/traefik-crds.yaml directly.
     - git:
         repoURL: https://github.com/andyleap-cluster/cluster.git
         branch: master

--- a/kargo-projects/traefik/stage.yaml
+++ b/kargo-projects/traefik/stage.yaml
@@ -22,6 +22,9 @@ spec:
               - branch: live
                 create: true
                 path: ./out
+        # Sync this Stage's owned slice (traefik/) from master to live.
+        # Clear first so files removed on master don't linger.
+        # cluster/traefik.yaml is owned by the kargo-cluster Stage.
         - uses: git-clear
           # First promotion against a fresh live has no ./out/traefik — that's
           # expected; ignore the resulting "no such file or directory" error.
@@ -30,18 +33,8 @@ spec:
             path: ./out/traefik
         - uses: copy
           config:
-            inPath: ./src/cluster/traefik.yaml
-            outPath: ./out/cluster/traefik.yaml
-        - uses: copy
-          config:
             inPath: ./src/traefik
             outPath: ./out/traefik
-        - uses: yaml-update
-          config:
-            path: ./out/cluster/traefik.yaml
-            updates:
-              - key: spec.sources.0.targetRevision
-                value: ${{ chartFrom("https://traefik.github.io/charts", "traefik").Version }}
         - uses: yaml-update
           config:
             path: ./out/traefik/values.yaml
@@ -52,7 +45,7 @@ spec:
           config:
             path: ./out
             message: |
-              kargo: bump traefik to chart ${{ chartFrom("https://traefik.github.io/charts", "traefik").Version }} / image ${{ imageFrom("docker.io/traefik").Tag }}
+              kargo: bump traefik image to ${{ imageFrom("docker.io/traefik").Tag }}
         - uses: git-push
           config:
             path: ./out

--- a/kargo-projects/traefik/warehouse.yaml
+++ b/kargo-projects/traefik/warehouse.yaml
@@ -5,10 +5,9 @@ metadata:
   namespace: kargo-traefik
 spec:
   subscriptions:
-    - chart:
-        repoURL: https://traefik.github.io/charts
-        name: traefik
-        semverConstraint: ">=34.0.0 <41.0.0"
+    # Chart-version auto-bumps were dropped (see #71). Chart upgrades
+    # are landed as manual PRs that edit cluster/traefik.yaml directly.
+    # Image bumps still drive automated promotions.
     - image:
         repoURL: docker.io/traefik
         imageSelectionStrategy: SemVer


### PR DESCRIPTION
## Summary

Refactors Kargo Stage ownership so the `kargo-cluster:main` Stage is the sole owner of the `cluster/` directory on the live branch, per #71.

- `kargo-cluster:main` Stage replaces its two specific `copy` steps (`cluster.yaml`, `kustomization.yaml`) with `git-clear ./out/cluster` + full directory `copy ./src/cluster -> ./out/cluster`. File additions and deletions in `cluster/` both propagate cleanly — no more orphan files when an app is retired.
- Per-app Stages (argocd, cert-manager, cert-manager-webhook-linode, kargo, kargo-projects, pocket-id, traefik, traefik-crds) drop their `copy` step that writes `./out/cluster/<app>.yaml` and any `yaml-update` step targeting that file. Per-app Stages only own their respective `<app>/` directory.
- Image-tag bumps stay where they were (traefik, cert-manager-webhook-linode, pocket-id) — they edit files inside the per-app `<app>/` dir.

## Chart-version auto-bumps dropped

Per the issue's option 3 (the recommended one), chart-version auto-bumps are dropped entirely. Chart upgrades become manual PRs that edit `cluster/<app>.yaml` directly. Now-unused chart (and git-tag-as-chart) subscriptions are removed from these Warehouses so they don't fire no-op promotions:

- argocd
- cert-manager
- cert-manager-webhook-linode (drops the linode/cert-manager-webhook-linode git-tag sub; image sub stays)
- kargo
- traefik (drops chart sub; image sub stays)
- traefik-crds

The comment on `cluster/kustomization.yaml` is updated to reflect the new ownership story — the explicit Application registry is still useful, just no longer needed for orphan-file protection.

Closes #71.

## Test plan

- [ ] `kubectl kustomize kargo-projects/` renders cleanly (verified locally — 708 lines).
- [ ] `kubectl kustomize cluster/` renders cleanly (verified locally — 294 lines).
- [ ] After merge, watch ArgoCD reconcile `kargo-projects` and verify each Stage CR has the new promotion template (no `./out/cluster/...` writes outside the `kargo-cluster` Stage).
- [ ] Trigger a Kargo promotion (e.g. push a no-op commit to master) and confirm:
  - `kargo-cluster:main` runs and mirrors the entire `cluster/` dir to live.
  - Per-app Stages run and only touch their own dir on live.
- [ ] Confirm follow-up retirements (e.g. a future app removal) now drop the `cluster/<app>.yaml` from live automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)