### PR TITLE
Add daily live-branch orphan sweep workflow

### DIFF
--- a/.github/workflows/live-orphan-sweep.yml
+++ b/.github/workflows/live-orphan-sweep.yml
@@ -1,0 +1,80 @@
+name: 'Live Orphan Sweep'
+
+on:
+  schedule:
+    - cron: '17 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: live-orphan-sweep
+  cancel-in-progress: false
+
+jobs:
+  sweep:
+    name: 'Sweep orphan paths on live'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout default branch (for the script)
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install PyYAML
+        run: pip install pyyaml
+
+      - name: Materialize live in a worktree
+        run: |
+          git fetch origin live
+          git worktree add ../live origin/live
+
+      - name: Skip if a sweep PR is already open
+        id: skip
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          n=$(gh pr list --label live-orphan-sweep --state open --base live --json number --jq 'length')
+          echo "open=$n" >> "$GITHUB_OUTPUT"
+          if [ "$n" != "0" ]; then
+            echo "::notice::An open live-orphan-sweep PR already exists; skipping run."
+          fi
+
+      - name: Compute orphan paths
+        if: steps.skip.outputs.open == '0'
+        id: compute
+        run: |
+          python3 scripts/find-live-orphans.py ../live > orphans.txt
+          if [ -s orphans.txt ]; then
+            echo "has_orphans=1" >> "$GITHUB_OUTPUT"
+            echo "Orphans found:"
+            cat orphans.txt
+          else
+            echo "has_orphans=0" >> "$GITHUB_OUTPUT"
+            echo "No orphans."
+          fi
+
+      - name: Open sweep PR
+        if: steps.skip.outputs.open == '0' && steps.compute.outputs.has_orphans == '1'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        working-directory: ../live
+        run: |
+          branch="automation/live-orphan-sweep-$(date -u +%Y-%m-%d)"
+          git config user.name 'kargo-sweep'
+          git config user.email 'sweep@andyleap.dev'
+          git switch -c "$branch"
+          xargs -d '\n' -a "$GITHUB_WORKSPACE/orphans.txt" git rm -r --
+          git commit -m 'Sweep orphan paths from live branch'
+          git push -u origin "$branch"
+          gh pr create \
+            --base live \
+            --head "$branch" \
+            --title 'Sweep orphan paths from live' \
+            --label live-orphan-sweep \
+            --body 'Automated daily sweep of paths on `live` not owned by any Kargo Stage. Inspect the diff.'

--- a/scripts/find-live-orphans.py
+++ b/scripts/find-live-orphans.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Find paths on the live branch that are not owned by any Kargo Stage.
+
+Parses every kargo-projects/*/stage.yaml at the given checkout root,
+collects the outPath of every `uses: copy` promotion step, classifies
+each as a file (exact-match) or subtree (prefix-match) ownership claim,
+then walks the checkout and emits one orphan path per line (relative to
+the checkout root) suitable for `xargs -d '\\n' git rm -r --`.
+
+The classification of file-vs-subtree is decided by looking at the
+corresponding source path (inPath) on disk: if the source is a file,
+the outPath is a file claim; if it's a directory, the outPath is a
+subtree claim.
+
+A directory is emitted as a single orphan only when no path under it is
+owned; otherwise the script recurses and emits the unowned leaves.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+import yaml
+
+
+SRC_PREFIX = "./src/"
+OUT_PREFIX = "./out/"
+
+
+def parse_stages(root: Path):
+    expected_files: set[str] = set()
+    expected_subtrees: set[str] = set()
+
+    for stage_file in sorted((root / "kargo-projects").glob("*/stage.yaml")):
+        with stage_file.open() as f:
+            stage = yaml.safe_load(f) or {}
+        steps = (
+            stage.get("spec", {})
+            .get("promotionTemplate", {})
+            .get("spec", {})
+            .get("steps", [])
+        )
+        for step in steps:
+            if step.get("uses") != "copy":
+                continue
+            cfg = step.get("config", {}) or {}
+            in_path = cfg.get("inPath", "")
+            out_path = cfg.get("outPath", "")
+            if not out_path.startswith(OUT_PREFIX):
+                continue
+            out_rel = out_path[len(OUT_PREFIX):].strip("/")
+            if not out_rel:
+                continue
+            if not in_path.startswith(SRC_PREFIX):
+                continue
+            src = root / in_path[len(SRC_PREFIX):]
+            if src.is_file():
+                expected_files.add(out_rel)
+            elif src.is_dir():
+                expected_subtrees.add(out_rel)
+            else:
+                sys.stderr.write(
+                    f"warning: {stage_file}: source {src} does not exist on live; "
+                    f"skipping outPath {out_path}\n"
+                )
+                continue
+
+    return expected_files, expected_subtrees
+
+
+def find_orphans(root: Path, files: set[str], subtrees: set[str]) -> list[str]:
+    orphans: list[str] = []
+
+    def under_subtree(rel: str) -> bool:
+        return any(rel == d or rel.startswith(d + "/") for d in subtrees)
+
+    def has_owned_descendant(rel: str) -> bool:
+        prefix = rel + "/"
+        return any(p.startswith(prefix) for p in files) or any(
+            p.startswith(prefix) for p in subtrees
+        )
+
+    def walk(rel: str) -> None:
+        if rel and under_subtree(rel):
+            return
+        directory = root if not rel else root / rel
+        for entry in sorted(os.listdir(directory)):
+            if entry == ".git":
+                continue
+            child_rel = f"{rel}/{entry}" if rel else entry
+            child = directory / entry
+            if child.is_file():
+                if child_rel not in files:
+                    orphans.append(child_rel)
+            elif child.is_dir():
+                if child_rel in subtrees:
+                    continue
+                if has_owned_descendant(child_rel):
+                    walk(child_rel)
+                else:
+                    orphans.append(child_rel)
+
+    walk("")
+    return orphans
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        sys.stderr.write(f"usage: {sys.argv[0]} <live-checkout-root>\n")
+        return 2
+    root = Path(sys.argv[1]).resolve()
+    if not (root / "kargo-projects").is_dir():
+        sys.stderr.write(f"{root}: no kargo-projects/ directory found\n")
+        return 2
+    files, subtrees = parse_stages(root)
+    for orphan in find_orphans(root, files, subtrees):
+        print(orphan)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Daily GitHub Actions workflow parses live's `kargo-projects/*/stage.yaml`, computes the set of paths owned by some `uses: copy` step, and opens a PR against `live` to `git rm` anything else.
- `scripts/find-live-orphans.py` does the parsing. File-vs-subtree ownership is inferred from whether each step's `inPath` is a file or directory on disk.
- Dedup via the `live-orphan-sweep` label — a new run that finds an existing open sweep PR exits without opening another.

Closes #70.

## How it decides ownership

- `./src/argocd → ./out/argocd` ⇒ `argocd/` is a subtree claim; everything inside is owned.
- `./src/cluster/argocd.yaml → ./out/cluster/argocd.yaml` ⇒ only that exact path is claimed; siblings in `cluster/` need their own claim.
- Directories with no owned descendants are emitted as a single orphan (`git rm -r`).
- Partially-owned directories are recursed into so only unowned leaves come out.

## Current orphan set

Run against today's live, the script emits exactly:

```
gateway-api
```

That's the top-level dir left over from PR #65's retirement that PR #67 cleaned manually but never structurally — the first sweep PR will remove it.

## Test plan

- [ ] Workflow appears in Actions tab after merge.
- [ ] Manually trigger via `workflow_dispatch`; verify it opens a PR proposing to delete `gateway-api/`.
- [ ] Merge the sweep PR; verify a second `workflow_dispatch` exits clean (no orphans, no PR opened).
- [ ] Open a dummy PR with the `live-orphan-sweep` label; verify a third `workflow_dispatch` skips with the "already open" notice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)