### PR TITLE
Live orphan sweep: drop stale branch from same-day retries

### DIFF
--- a/.github/workflows/live-orphan-sweep.yml
+++ b/.github/workflows/live-orphan-sweep.yml
@@ -68,6 +68,10 @@ jobs:
           branch="automation/live-orphan-sweep-$(date -u +%Y-%m-%d)"
           git config user.name 'kargo-sweep'
           git config user.email 'sweep@andyleap.dev'
+          # Wipe any stale branch left by a same-day retry whose PR has
+          # since been closed — the open-PR skip check above already
+          # protects the in-flight case.
+          git push origin --delete "$branch" 2>/dev/null || true
           git switch -c "$branch"
           xargs -d '\n' -a "$GITHUB_WORKSPACE/orphans.txt" git rm -r --
           git commit -m 'Sweep orphan paths from live branch'


### PR DESCRIPTION
## Summary
- The sweep workflow's branch name only varies by UTC date, so a same-day retry whose previous PR is no longer open collides on the stale remote ref at `git push -u origin "$branch"`.
- The open-PR label skip check at line 42 already protects the in-flight case; this just deletes the stale remote branch (if any) before recreating it, so retries are clean.

## Test plan
- [ ] Manually `workflow_dispatch` the workflow twice in a row on a day where it produces orphans, closing the first PR between runs, and confirm the second run pushes a fresh branch and opens a new PR.
- [ ] Confirm that a single-run dispatch on a clean day still works (the `--delete` no-ops via `|| true` when the ref doesn't exist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)