### PR TITLE
Wire up TinyOAuth ForwardAuth bouncer

### DIFF
--- a/cluster/kustomization.yaml
+++ b/cluster/kustomization.yaml
@@ -18,5 +18,6 @@ resources:
   - kargo-projects.yaml
   - kargo.yaml
   - pocket-id.yaml
+  - tinyoauth.yaml
   - traefik-crds.yaml
   - traefik.yaml

--- a/cluster/tinyoauth.yaml
+++ b/cluster/tinyoauth.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: tinyoauth
+  namespace: argocd
+  annotations:
+    kargo.akuity.io/authorized-stage: "kargo-tinyoauth:main"
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: 'https://github.com/andyleap-cluster/cluster.git'
+    targetRevision: live
+    path: tinyoauth
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: tinyoauth
+  syncPolicy:
+    automated:
+      selfHeal: true
+      prune: true
+    syncOptions:
+    - CreateNamespace=true
+    - ServerSideApply=true

--- a/kargo-projects/kustomization.yaml
+++ b/kargo-projects/kustomization.yaml
@@ -9,5 +9,6 @@ resources:
   - kargo
   - kargo-projects
   - pocket-id
+  - tinyoauth
   - traefik
   - traefik-crds

--- a/kargo-projects/tinyoauth/kustomization.yaml
+++ b/kargo-projects/tinyoauth/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- project.yaml
+- projectconfig.yaml
+- warehouse.yaml
+- stage.yaml

--- a/kargo-projects/tinyoauth/project.yaml
+++ b/kargo-projects/tinyoauth/project.yaml
@@ -1,0 +1,4 @@
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Project
+metadata:
+  name: kargo-tinyoauth

--- a/kargo-projects/tinyoauth/projectconfig.yaml
+++ b/kargo-projects/tinyoauth/projectconfig.yaml
@@ -1,0 +1,9 @@
+apiVersion: kargo.akuity.io/v1alpha1
+kind: ProjectConfig
+metadata:
+  name: kargo-tinyoauth
+  namespace: kargo-tinyoauth
+spec:
+  promotionPolicies:
+    - stage: main
+      autoPromotionEnabled: true

--- a/kargo-projects/tinyoauth/stage.yaml
+++ b/kargo-projects/tinyoauth/stage.yaml
@@ -1,0 +1,58 @@
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+metadata:
+  name: main
+  namespace: kargo-tinyoauth
+spec:
+  requestedFreight:
+    - origin:
+        kind: Warehouse
+        name: tinyoauth
+      sources:
+        direct: true
+  promotionTemplate:
+    spec:
+      steps:
+        - uses: git-clone
+          config:
+            repoURL: git@github.com:andyleap-cluster/cluster.git
+            checkout:
+              - branch: master
+                path: ./src
+              - branch: live
+                create: true
+                path: ./out
+        - uses: git-clear
+          # First promotion against a fresh live has no ./out/tinyoauth — that's
+          # expected; ignore the resulting "no such file or directory" error.
+          continueOnError: true
+          config:
+            path: ./out/tinyoauth
+        - uses: copy
+          config:
+            inPath: ./src/cluster/tinyoauth.yaml
+            outPath: ./out/cluster/tinyoauth.yaml
+        - uses: copy
+          config:
+            inPath: ./src/tinyoauth
+            outPath: ./out/tinyoauth
+        - uses: yaml-update
+          config:
+            path: ./out/tinyoauth/kustomization.yaml
+            updates:
+              - key: images.0.newTag
+                value: ${{ imageFrom("ghcr.io/andyleap/tinyoauth").Tag }}
+        - uses: git-commit
+          config:
+            path: ./out
+            message: |
+              kargo: bump tinyoauth image to ${{ imageFrom("ghcr.io/andyleap/tinyoauth").Tag }}
+        - uses: git-push
+          config:
+            path: ./out
+            targetBranch: live
+        - uses: argocd-update
+          config:
+            apps:
+              - name: tinyoauth
+                namespace: argocd

--- a/kargo-projects/tinyoauth/warehouse.yaml
+++ b/kargo-projects/tinyoauth/warehouse.yaml
@@ -1,0 +1,17 @@
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Warehouse
+metadata:
+  name: tinyoauth
+  namespace: kargo-tinyoauth
+spec:
+  subscriptions:
+    - image:
+        repoURL: ghcr.io/andyleap/tinyoauth
+        imageSelectionStrategy: SemVer
+        semverConstraint: ">=0.1.0 <1.0.0"
+        strictSemvers: true
+    - git:
+        repoURL: https://github.com/andyleap-cluster/cluster.git
+        branch: master
+        commitSelectionStrategy: NewestFromBranch
+        strictSemvers: false

--- a/terraform/tinyoauth.tf
+++ b/terraform/tinyoauth.tf
@@ -1,3 +1,12 @@
+# Namespace must exist before the Secret can be created. ArgoCD would create it
+# via CreateNamespace=true, but Terraform runs before ArgoCD on a fresh cluster,
+# so we own the namespace here.
+resource "kubernetes_namespace" "tinyoauth" {
+  metadata {
+    name = "tinyoauth"
+  }
+}
+
 # TinyOAuth session encryption key. 32 random bytes encoded as 64 hex chars,
 # which is what TinyOAuth's AES-256-GCM session codec expects.
 resource "random_bytes" "tinyoauth_cookie_secret" {
@@ -10,7 +19,7 @@ resource "random_bytes" "tinyoauth_cookie_secret" {
 resource "kubernetes_secret" "tinyoauth_secret" {
   metadata {
     name      = "tinyoauth-secret"
-    namespace = "tinyoauth"
+    namespace = kubernetes_namespace.tinyoauth.metadata[0].name
   }
 
   data = {

--- a/terraform/tinyoauth.tf
+++ b/terraform/tinyoauth.tf
@@ -1,0 +1,19 @@
+# TinyOAuth session encryption key. 32 random bytes encoded as 64 hex chars,
+# which is what TinyOAuth's AES-256-GCM session codec expects.
+resource "random_bytes" "tinyoauth_cookie_secret" {
+  length = 32
+}
+
+# Injects TINYOAUTH_COOKIE_SECRET into the tinyoauth Deployment via envFrom.
+# The config.yaml ConfigMap (in git) intentionally omits cookie_secret;
+# TinyOAuth's applyEnvFallbacks fills it from this env var at startup.
+resource "kubernetes_secret" "tinyoauth_secret" {
+  metadata {
+    name      = "tinyoauth-secret"
+    namespace = "tinyoauth"
+  }
+
+  data = {
+    TINYOAUTH_COOKIE_SECRET = random_bytes.tinyoauth_cookie_secret.hex
+  }
+}

--- a/tinyoauth/configmap.yaml
+++ b/tinyoauth/configmap.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tinyoauth-config
+  namespace: tinyoauth
+data:
+  config.yaml: |
+    listen: ":4180"
+    auth_host: "auth.andyleap.dev"
+    issuer: "https://id.andyleap.dev"
+    cookie_name: "_tinyoauth"
+    cookie_domain: ".andyleap.dev"
+    session_ttl: "12h"
+    annotation_prefix: "tinyoauth.andyleap.dev"
+    namespace: "tinyoauth"
+    service_account: "tinyoauth"
+    # cookie_secret is intentionally absent — injected at runtime via
+    # TINYOAUTH_COOKIE_SECRET from the tinyoauth-secret K8s Secret (Terraform-managed).

--- a/tinyoauth/deployment.yaml
+++ b/tinyoauth/deployment.yaml
@@ -1,0 +1,62 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tinyoauth
+  namespace: tinyoauth
+  labels:
+    app.kubernetes.io/name: tinyoauth
+spec:
+  replicas: 2
+  revisionHistoryLimit: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: tinyoauth
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: tinyoauth
+    spec:
+      serviceAccountName: tinyoauth
+      securityContext:
+        runAsNonRoot: true
+      volumes:
+        - name: config
+          configMap:
+            name: tinyoauth-config
+      containers:
+        - name: tinyoauth
+          image: ghcr.io/andyleap/tinyoauth:v0.1.0
+          args: ["--config=/etc/tinyoauth/config.yaml"]
+          envFrom:
+            - secretRef:
+                name: tinyoauth-secret
+          ports:
+            - name: http
+              containerPort: 4180
+              protocol: TCP
+          volumeMounts:
+            - name: config
+              mountPath: /etc/tinyoauth
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL

--- a/tinyoauth/httproute.yaml
+++ b/tinyoauth/httproute.yaml
@@ -1,0 +1,25 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: tinyoauth
+  namespace: tinyoauth
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: traefik-gateway
+      namespace: traefik
+      sectionName: websecure
+  hostnames:
+    - auth.andyleap.dev
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - group: ""
+          kind: Service
+          name: tinyoauth
+          port: 80
+          weight: 1

--- a/tinyoauth/kustomization.yaml
+++ b/tinyoauth/kustomization.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: tinyoauth
+
+resources:
+  - configmap.yaml
+  - serviceaccount.yaml
+  - rbac.yaml
+  - deployment.yaml
+  - service.yaml
+  - httproute.yaml
+
+# Kargo's kargo-tinyoauth:main Stage rewrites images.0.newTag on each
+# promotion. The tinyoauth-secret (TINYOAUTH_COOKIE_SECRET) lives in
+# Terraform, not here, so this kustomization intentionally does not include it.
+images:
+  - name: ghcr.io/andyleap/tinyoauth
+    newTag: v0.1.0

--- a/tinyoauth/rbac.yaml
+++ b/tinyoauth/rbac.yaml
@@ -1,0 +1,52 @@
+# Cluster-wide read access to Traefik Middlewares and ConfigMaps.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tinyoauth-reader
+rules:
+- apiGroups: ["traefik.io"]
+  resources: ["middlewares"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tinyoauth-reader
+subjects:
+- kind: ServiceAccount
+  name: tinyoauth
+  namespace: tinyoauth
+roleRef:
+  kind: ClusterRole
+  name: tinyoauth-reader
+  apiGroup: rbac.authorization.k8s.io
+---
+# Permission to mint SA tokens for the bouncer's own SA only.
+# resourceNames pins this to self so it cannot mint tokens for any other identity.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: tinyoauth-self-token
+  namespace: tinyoauth
+rules:
+- apiGroups: [""]
+  resources: ["serviceaccounts/token"]
+  resourceNames: ["tinyoauth"]
+  verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tinyoauth-self-token
+  namespace: tinyoauth
+subjects:
+- kind: ServiceAccount
+  name: tinyoauth
+  namespace: tinyoauth
+roleRef:
+  kind: Role
+  name: tinyoauth-self-token
+  apiGroup: rbac.authorization.k8s.io

--- a/tinyoauth/service.yaml
+++ b/tinyoauth/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: tinyoauth
+  namespace: tinyoauth
+spec:
+  selector:
+    app.kubernetes.io/name: tinyoauth
+  ports:
+  - port: 80
+    targetPort: 4180

--- a/tinyoauth/service.yaml
+++ b/tinyoauth/service.yaml
@@ -4,8 +4,11 @@ metadata:
   name: tinyoauth
   namespace: tinyoauth
 spec:
+  type: ClusterIP
   selector:
     app.kubernetes.io/name: tinyoauth
   ports:
-  - port: 80
-    targetPort: 4180
+    - name: http
+      port: 80
+      targetPort: http
+      protocol: TCP

--- a/tinyoauth/serviceaccount.yaml
+++ b/tinyoauth/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tinyoauth
+  namespace: tinyoauth


### PR DESCRIPTION
## Summary

- Deploys [TinyOAuth](https://github.com/andyleap/tinyoauth) — a Traefik ForwardAuth bouncer using RFC 7523 JWT-bearer client auth to Pocket ID (no shared `client_secret`)
- Sets up the full GitOps pipeline: ArgoCD Application → Kargo image promotion (SemVer `>=0.1.0 <1.0.0` on `ghcr.io/andyleap/tinyoauth`) → `live` branch
- Exposes TinyOAuth at `auth.andyleap.dev` via the existing Traefik Gateway

## What's included

| Path | Purpose |
|------|---------|
| `tinyoauth/` | Kustomize manifests: ConfigMap (non-sensitive config), ServiceAccount, RBAC, Deployment (2 replicas), Service, HTTPRoute |
| `cluster/tinyoauth.yaml` | ArgoCD Application tracking `live` branch |
| `kargo-projects/tinyoauth/` | Warehouse + Stage — mirrors pocket-id promotion pipeline |
| `terraform/tinyoauth.tf` | Generates `TINYOAUTH_COOKIE_SECRET` and creates `tinyoauth-secret` K8s Secret |

## How the secret is injected

`cookie_secret` is intentionally absent from the git-tracked ConfigMap. Terraform generates a 32-byte random key and creates a `tinyoauth-secret` K8s Secret in the `tinyoauth` namespace. The Deployment sources it via `envFrom: secretRef`, and TinyOAuth's `applyEnvFallbacks` picks it up from `TINYOAUTH_COOKIE_SECRET` at startup.

## Test plan

- [ ] Terraform apply creates `tinyoauth-secret` in `tinyoauth` namespace before first pod starts
- [ ] `kubectl get pods -n tinyoauth` — 2 replicas Running
- [ ] `kubectl get httproute -n tinyoauth` — `auth.andyleap.dev` admitted by Traefik Gateway
- [ ] `curl -I https://auth.andyleap.dev/healthz` → `204 No Content`
- [ ] Kargo promotes `v0.1.0` to `live` and ArgoCD syncs cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)