### PR TITLE
Fix tinyoauth runAsNonRoot: pin numeric UID 65532

### DIFF
--- a/tinyoauth/deployment.yaml
+++ b/tinyoauth/deployment.yaml
@@ -19,6 +19,8 @@ spec:
       serviceAccountName: tinyoauth
       securityContext:
         runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
       volumes:
         - name: config
           configMap:


### PR DESCRIPTION
## Summary

- Fixes pod startup failure: `container has runAsNonRoot and image has non-numeric user (nonroot), cannot verify user is non-root`

## Root cause

`gcr.io/distroless/static:nonroot` runs as the named user `nonroot` rather than a numeric UID. The kubelet rejects the pod because it cannot verify `runAsNonRoot: true` without a numeric user ID at admission time.

## Fix

Set `runAsUser: 65532` and `runAsGroup: 65532` (the numeric UID/GID for `nonroot` in distroless images) on the pod-level `securityContext`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)