### PR TITLE
Integrate simplelog log aggregator

### DIFF
--- a/cluster/kustomization.yaml
+++ b/cluster/kustomization.yaml
@@ -18,6 +18,7 @@ resources:
   - kargo-projects.yaml
   - kargo.yaml
   - pocket-id.yaml
+  - simplelog.yaml
   - tinyoauth.yaml
   - traefik-crds.yaml
   - traefik.yaml

--- a/cluster/simplelog.yaml
+++ b/cluster/simplelog.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: simplelog
+  namespace: argocd
+  annotations:
+    kargo.akuity.io/authorized-stage: "kargo-simplelog:main"
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: 'https://github.com/andyleap-cluster/cluster.git'
+    targetRevision: live
+    path: simplelog
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: simplelog
+  syncPolicy:
+    automated:
+      selfHeal: true
+      prune: true
+    syncOptions:
+    - CreateNamespace=true
+    - ServerSideApply=true

--- a/kargo-projects/kustomization.yaml
+++ b/kargo-projects/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - kargo
   - kargo-projects
   - pocket-id
+  - simplelog
   - tinyoauth
   - traefik
   - traefik-crds

--- a/kargo-projects/simplelog/kustomization.yaml
+++ b/kargo-projects/simplelog/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- project.yaml
+- projectconfig.yaml
+- warehouse.yaml
+- stage.yaml

--- a/kargo-projects/simplelog/project.yaml
+++ b/kargo-projects/simplelog/project.yaml
@@ -1,0 +1,4 @@
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Project
+metadata:
+  name: kargo-simplelog

--- a/kargo-projects/simplelog/projectconfig.yaml
+++ b/kargo-projects/simplelog/projectconfig.yaml
@@ -1,0 +1,9 @@
+apiVersion: kargo.akuity.io/v1alpha1
+kind: ProjectConfig
+metadata:
+  name: kargo-simplelog
+  namespace: kargo-simplelog
+spec:
+  promotionPolicies:
+    - stage: main
+      autoPromotionEnabled: true

--- a/kargo-projects/simplelog/stage.yaml
+++ b/kargo-projects/simplelog/stage.yaml
@@ -1,0 +1,60 @@
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+metadata:
+  name: main
+  namespace: kargo-simplelog
+spec:
+  requestedFreight:
+    - origin:
+        kind: Warehouse
+        name: simplelog
+      sources:
+        direct: true
+  promotionTemplate:
+    spec:
+      steps:
+        - uses: git-clone
+          config:
+            repoURL: git@github.com:andyleap-cluster/cluster.git
+            checkout:
+              - branch: master
+                path: ./src
+              - branch: live
+                create: true
+                path: ./out
+        - uses: git-clear
+          # First promotion against a fresh live has no ./out/simplelog — that's
+          # expected; ignore the resulting "no such file or directory" error.
+          continueOnError: true
+          config:
+            path: ./out/simplelog
+        - uses: copy
+          config:
+            inPath: ./src/cluster/simplelog.yaml
+            outPath: ./out/cluster/simplelog.yaml
+        - uses: copy
+          config:
+            inPath: ./src/simplelog
+            outPath: ./out/simplelog
+        - uses: yaml-update
+          config:
+            path: ./out/simplelog/kustomization.yaml
+            updates:
+              - key: images.0.newTag
+                value: ${{ imageFrom("ghcr.io/andyleap/simplelog-manager").Tag }}
+              - key: images.1.newTag
+                value: ${{ imageFrom("ghcr.io/andyleap/simplelog-agent").Tag }}
+        - uses: git-commit
+          config:
+            path: ./out
+            message: |
+              kargo: bump simplelog images to ${{ imageFrom("ghcr.io/andyleap/simplelog-manager").Tag }}
+        - uses: git-push
+          config:
+            path: ./out
+            targetBranch: live
+        - uses: argocd-update
+          config:
+            apps:
+              - name: simplelog
+                namespace: argocd

--- a/kargo-projects/simplelog/warehouse.yaml
+++ b/kargo-projects/simplelog/warehouse.yaml
@@ -1,0 +1,24 @@
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Warehouse
+metadata:
+  name: simplelog
+  namespace: kargo-simplelog
+spec:
+  subscriptions:
+    # GoReleaser builds and tags both images identically per release, so they
+    # advance together. Both are pinned to the same tag in the kustomization.
+    - image:
+        repoURL: ghcr.io/andyleap/simplelog-manager
+        imageSelectionStrategy: SemVer
+        semverConstraint: ">=0.1.0 <1.0.0"
+        strictSemvers: true
+    - image:
+        repoURL: ghcr.io/andyleap/simplelog-agent
+        imageSelectionStrategy: SemVer
+        semverConstraint: ">=0.1.0 <1.0.0"
+        strictSemvers: true
+    - git:
+        repoURL: https://github.com/andyleap-cluster/cluster.git
+        branch: master
+        commitSelectionStrategy: NewestFromBranch
+        strictSemvers: false

--- a/simplelog/agent-daemonset.yaml
+++ b/simplelog/agent-daemonset.yaml
@@ -1,11 +1,17 @@
 # simplelog agent: DaemonSet on every node. Read-only access to pod logs plus a
-# node-scoped Pod watch for metadata enrichment. The checkpoint lives on a
-# hostPath so a restarted agent resumes from the last acked offset.
+# cluster-wide Pod read for metadata enrichment (the agent filters to its own
+# node at runtime; the RBAC itself is cluster-scoped — see rbac.yaml). The
+# checkpoint lives on a hostPath so a restarted agent resumes from the last
+# acked offset.
 #
 # NB: unlike the rest of the cluster, this pod intentionally runs as root with
 # NO restrictive securityContext. The agent must read root-owned host log files
-# under /var/log/pods and /var/lib/docker/containers; forcing runAsNonRoot would
-# break log collection. Access is constrained to read-only host mounts.
+# under /var/log/pods; forcing runAsNonRoot would break log collection. The log
+# mount is read-only; only the checkpoint mount (/var/lib/simplelog) is writable.
+#
+# LKE nodes run containerd, so the CRI writes the real log files directly under
+# /var/log/pods (the upstream's extra /var/lib/docker/containers mount is for
+# Docker-runtime nodes and is omitted here — that path does not exist on LKE).
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -61,19 +67,12 @@ spec:
             - name: pod-logs
               mountPath: /var/log/pods
               readOnly: true
-            # /var/log/pods symlinks into the container runtime dir; mount it too.
-            - name: container-logs
-              mountPath: /var/lib/docker/containers
-              readOnly: true
             - name: checkpoint
               mountPath: /var/lib/simplelog
       volumes:
         - name: pod-logs
           hostPath:
             path: /var/log/pods
-        - name: container-logs
-          hostPath:
-            path: /var/lib/docker/containers
         - name: checkpoint
           hostPath:
             path: /var/lib/simplelog

--- a/simplelog/agent-daemonset.yaml
+++ b/simplelog/agent-daemonset.yaml
@@ -1,0 +1,80 @@
+# simplelog agent: DaemonSet on every node. Read-only access to pod logs plus a
+# node-scoped Pod watch for metadata enrichment. The checkpoint lives on a
+# hostPath so a restarted agent resumes from the last acked offset.
+#
+# NB: unlike the rest of the cluster, this pod intentionally runs as root with
+# NO restrictive securityContext. The agent must read root-owned host log files
+# under /var/log/pods and /var/lib/docker/containers; forcing runAsNonRoot would
+# break log collection. Access is constrained to read-only host mounts.
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: simplelog-agent
+  namespace: simplelog
+  labels:
+    app.kubernetes.io/name: simplelog-agent
+spec:
+  revisionHistoryLimit: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: simplelog-agent
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: simplelog-agent
+      # Opt this pod out of ingestion so simplelog's own logs are never tailed.
+      annotations:
+        simplelog.io/ingest: "false"
+    spec:
+      serviceAccountName: simplelog-agent
+      tolerations:
+        - operator: Exists # run on every node, including control-plane/tainted
+      containers:
+        - name: agent
+          image: ghcr.io/andyleap/simplelog-agent:v0.1.0
+          env:
+            - name: SL_MANAGER_ADDR
+              value: "simplelog-manager.simplelog.svc:9000"
+            - name: SL_LOG_ROOT
+              value: "/var/log/pods"
+            - name: SL_CHECKPOINT
+              value: "/var/lib/simplelog/checkpoint.db"
+            - name: SL_MAX_HELD_BYTES
+              value: "67108864" # 64 MiB soft cap
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            # Own namespace is always self-excluded (race-free guard against
+            # log loops, independent of the annotation/informer).
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              memory: 256Mi
+          volumeMounts:
+            - name: pod-logs
+              mountPath: /var/log/pods
+              readOnly: true
+            # /var/log/pods symlinks into the container runtime dir; mount it too.
+            - name: container-logs
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+            - name: checkpoint
+              mountPath: /var/lib/simplelog
+      volumes:
+        - name: pod-logs
+          hostPath:
+            path: /var/log/pods
+        - name: container-logs
+          hostPath:
+            path: /var/lib/docker/containers
+        - name: checkpoint
+          hostPath:
+            path: /var/lib/simplelog
+            type: DirectoryOrCreate

--- a/simplelog/httproute.yaml
+++ b/simplelog/httproute.yaml
@@ -1,0 +1,32 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: simplelog
+  namespace: simplelog
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: traefik-gateway
+      namespace: traefik
+      sectionName: websecure
+  hostnames:
+    - logs.andyleap.dev
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      # Gate the route through the TinyOAuth ForwardAuth middleware.
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: traefik.io
+            kind: Middleware
+            name: simplelog
+      backendRefs:
+        - group: ""
+          kind: Service
+          name: simplelog-manager
+          port: 8080
+          weight: 1

--- a/simplelog/kustomization.yaml
+++ b/simplelog/kustomization.yaml
@@ -1,0 +1,27 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: simplelog
+
+resources:
+  - serviceaccount.yaml
+  - rbac.yaml
+  - manager-config.yaml
+  - manager-statefulset.yaml
+  - manager-service.yaml
+  - agent-daemonset.yaml
+  - middleware.yaml
+  - tinyoauth-policy.yaml
+  - httproute.yaml
+
+# Kargo's kargo-simplelog:main Stage rewrites images.{0,1}.newTag on each
+# promotion. GoReleaser tags both images identically per release, so the
+# Warehouse pins them to the same version.
+#
+# The simplelog-s3 Secret (S3 credentials) and the tinyoauth-app-simplelog
+# ConfigMap (OIDC client_id) live in Terraform, not here, so this kustomization
+# intentionally does not include them.
+images:
+  - name: ghcr.io/andyleap/simplelog-manager
+    newTag: v0.1.0
+  - name: ghcr.io/andyleap/simplelog-agent
+    newTag: v0.1.0

--- a/simplelog/manager-config.yaml
+++ b/simplelog/manager-config.yaml
@@ -1,0 +1,15 @@
+# Non-secret S3 settings for the manager, pointed at the Linode Object Storage
+# bucket created in terraform/simplelog.tf. The credentials (SL_S3_ACCESS_KEY /
+# SL_S3_SECRET_KEY) are kept out of git and injected from the Terraform-managed
+# simplelog-s3 Secret via envFrom in the StatefulSet.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: simplelog-s3-config
+  namespace: simplelog
+data:
+  SL_S3_BUCKET: "andyleap-dev-simplelog"
+  SL_S3_DOMAIN: "us-sea-1.linodeobjects.com"
+  SL_S3_REGION: "us-sea-1"
+  SL_S3_PROTOCOL: "https"
+  SL_S3_PATH_STYLE: "true"

--- a/simplelog/manager-service.yaml
+++ b/simplelog/manager-service.yaml
@@ -1,0 +1,23 @@
+# Headless Service: stable DNS for the single manager replica. Serves as the
+# StatefulSet's governing service, the agents' ingest target (port 9000), and
+# the HTTPRoute backend for the query UI (port 8080).
+apiVersion: v1
+kind: Service
+metadata:
+  name: simplelog-manager
+  namespace: simplelog
+  labels:
+    app.kubernetes.io/name: simplelog-manager
+spec:
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: simplelog-manager
+  ports:
+    - name: ingest
+      port: 9000
+      targetPort: ingest
+      protocol: TCP
+    - name: http
+      port: 8080
+      targetPort: http
+      protocol: TCP

--- a/simplelog/manager-statefulset.yaml
+++ b/simplelog/manager-statefulset.yaml
@@ -1,0 +1,85 @@
+# simplelog manager: single-replica StatefulSet. No PVC — local disk is an
+# emptyDir scratch/cache and S3 is the only durable store; the catalog is
+# rebuilt from S3 on startup.
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: simplelog-manager
+  namespace: simplelog
+  labels:
+    app.kubernetes.io/name: simplelog-manager
+spec:
+  serviceName: simplelog-manager
+  replicas: 1
+  revisionHistoryLimit: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: simplelog-manager
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: simplelog-manager
+      # Opt this pod out of ingestion so the manager's own logs are never tailed.
+      annotations:
+        simplelog.io/ingest: "false"
+    spec:
+      # Generous grace period so SIGTERM can seal + upload the open segment.
+      terminationGracePeriodSeconds: 60
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        # fsGroup so the non-root process can write the emptyDir scratch at /data.
+        fsGroup: 65532
+      containers:
+        - name: manager
+          image: ghcr.io/andyleap/simplelog-manager:v0.1.0
+          args: ["-base-dir=/data"]
+          ports:
+            - name: ingest
+              containerPort: 9000
+              protocol: TCP
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          env:
+            - name: SL_MANAGER_ID
+              value: "mgr1"
+            - name: SL_SEG_BYTES
+              value: "67108864" # 64 MiB
+            - name: SL_SEG_AGE
+              value: "5m" # also bounds agent hold time
+            - name: SL_CACHE_BYTES
+              value: "2147483648" # 2 GiB
+          envFrom:
+            # Non-secret S3 settings (bucket/domain/region/protocol/pathStyle).
+            - configMapRef:
+                name: simplelog-s3-config
+            # SL_S3_ACCESS_KEY / SL_S3_SECRET_KEY (Terraform-managed).
+            - secretRef:
+                name: simplelog-s3
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 3
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              memory: 1Gi
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+      volumes:
+        # emptyDir: ephemeral scratch/cache/catalog. Lost on reschedule and
+        # rebuilt from S3 by the manager on startup.
+        - name: data
+          emptyDir:
+            sizeLimit: 4Gi

--- a/simplelog/middleware.yaml
+++ b/simplelog/middleware.yaml
@@ -1,0 +1,28 @@
+# TinyOAuth ForwardAuth gate for the simplelog query UI. simplelog has no
+# built-in auth, so every request to logs.andyleap.dev is checked by the
+# tinyoauth bouncer first.
+#
+# The forwardAuth.address embeds this Middleware's own <ns>/<name> so the
+# bouncer can resolve back to it: /check/simplelog/simplelog.
+#
+# The annotations reference:
+#   config-ref: tinyoauth-app-simplelog  (Terraform-owned: OIDC client_id + audience)
+#   policy-ref: tinyoauth-policy-simplelog (GitOps-owned: access rules, below)
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: simplelog
+  namespace: simplelog
+  annotations:
+    tinyoauth.andyleap.dev/config-ref: "tinyoauth-app-simplelog"
+    tinyoauth.andyleap.dev/policy-ref: "tinyoauth-policy-simplelog"
+spec:
+  forwardAuth:
+    address: "http://tinyoauth.tinyoauth.svc.cluster.local/check/simplelog/simplelog"
+    trustForwardHeader: true
+    authResponseHeaders:
+      - X-Auth-Request-User
+      - X-Auth-Request-Email
+      - X-Auth-Request-Preferred-Username
+      - X-Auth-Request-Name
+      - X-Auth-Request-Groups

--- a/simplelog/rbac.yaml
+++ b/simplelog/rbac.yaml
@@ -1,0 +1,22 @@
+# Node-scoped Pod watch for the agent's log metadata enrichment.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: simplelog-agent
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: simplelog-agent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: simplelog-agent
+subjects:
+  - kind: ServiceAccount
+    name: simplelog-agent
+    namespace: simplelog

--- a/simplelog/rbac.yaml
+++ b/simplelog/rbac.yaml
@@ -1,4 +1,6 @@
-# Node-scoped Pod watch for the agent's log metadata enrichment.
+# Cluster-wide read of Pods for the agent's log metadata enrichment. The agent
+# filters to its own node at runtime, but the permission itself is cluster-scoped
+# (a ClusterRole/ClusterRoleBinding — Pod watches can't be restricted by node).
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/simplelog/serviceaccount.yaml
+++ b/simplelog/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: simplelog-agent
+  namespace: simplelog

--- a/simplelog/tinyoauth-policy.yaml
+++ b/simplelog/tinyoauth-policy.yaml
@@ -1,0 +1,14 @@
+# Access policy for the simplelog UI (referenced by the Middleware's
+# policy-ref annotation). Only members of the simplelog-users Pocket ID group
+# (created in terraform/simplelog.tf) may reach the logs.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tinyoauth-policy-simplelog
+  namespace: simplelog
+data:
+  rules.yaml: |
+    default_allowed_groups: ["simplelog-users"]
+    rules:
+      - path_prefix: "/"
+        allowed_groups: ["simplelog-users"]

--- a/terraform/simplelog.tf
+++ b/terraform/simplelog.tf
@@ -1,0 +1,94 @@
+# simplelog: a self-hosted log aggregator. The agent DaemonSet ships container
+# logs to the manager, which archives them to a Linode Object Storage bucket
+# (the only durable store — no PVC; the manager rebuilds its catalog from S3 on
+# startup). LKE block-storage volumes have a per-volume minimum size that makes
+# them expensive for this kind of workload.
+#
+# The query UI has no built-in auth, so it's fronted by the TinyOAuth
+# ForwardAuth bouncer + a Pocket ID OIDC client (mirrors terraform/kargo-oidc.tf).
+# The K8s manifests live in ../simplelog and are deployed by ArgoCD; this file
+# owns only the namespace, the S3 bucket/credentials Secret, and the OIDC
+# client/group + the Terraform-owned tinyoauth config-ref ConfigMap.
+
+resource "kubernetes_namespace" "simplelog" {
+  metadata {
+    name = "simplelog"
+  }
+}
+
+resource "linode_object_storage_bucket" "simplelog" {
+  region = "us-sea"
+  label  = "andyleap-dev-simplelog"
+  acl    = "private"
+}
+
+resource "linode_object_storage_key" "simplelog" {
+  label = "simplelog"
+  bucket_access {
+    bucket_name = linode_object_storage_bucket.simplelog.label
+    region      = "us-sea"
+    permissions = "read_write"
+  }
+}
+
+# Only the S3 credentials are secret. The non-secret S3 settings
+# (bucket/domain/region/protocol/pathStyle) live in
+# ../simplelog/manager-config.yaml and are merged in via envFrom.
+resource "kubernetes_secret" "simplelog_s3" {
+  metadata {
+    name      = "simplelog-s3"
+    namespace = kubernetes_namespace.simplelog.metadata[0].name
+  }
+
+  data = {
+    SL_S3_ACCESS_KEY = linode_object_storage_key.simplelog.access_key
+    SL_S3_SECRET_KEY = linode_object_storage_key.simplelog.secret_key
+  }
+}
+
+# Group-based access control: only members of simplelog-users may reach the UI
+# (enforced by the policy in ../simplelog/tinyoauth-policy.yaml).
+resource "pocketid_group" "simplelog_users" {
+  name          = "simplelog-users"
+  friendly_name = "simplelog Users"
+}
+
+# OIDC client for the TinyOAuth bouncer's login flow on behalf of simplelog.
+# TinyOAuth is PKCE-only (no client_secret to manage); the config-ref ConfigMap
+# carries just the client_id + audience. The OAuth callback is served by
+# tinyoauth on its shared auth host, not on logs.andyleap.dev.
+#
+# NB: do not set `client_id` here -- the trozz/pocketid provider sends it as
+# JSON `clientId`, but Pocket ID's API expects `id`, so the custom value is
+# silently ignored and Pocket ID auto-generates a UUID instead. The
+# auto-generated value is exposed via `.id` and threaded into the ConfigMap below.
+resource "pocketid_client" "simplelog" {
+  name = "simplelog"
+
+  callback_urls = [
+    "https://auth.andyleap.dev/callback",
+  ]
+
+  logout_callback_urls = [
+    "https://auth.andyleap.dev/sign_out",
+  ]
+
+  is_public    = true
+  pkce_enabled = true
+  launch_url   = "https://logs.andyleap.dev"
+}
+
+# Terraform-owned config-ref ConfigMap that the simplelog Middleware references
+# via its tinyoauth.andyleap.dev/config-ref annotation. Threads Pocket ID's
+# auto-generated client id into the bouncer.
+resource "kubernetes_config_map" "tinyoauth_app_simplelog" {
+  metadata {
+    name      = "tinyoauth-app-simplelog"
+    namespace = kubernetes_namespace.simplelog.metadata[0].name
+  }
+
+  data = {
+    client_id = pocketid_client.simplelog.id
+    audience  = "https://id.andyleap.dev"
+  }
+}


### PR DESCRIPTION
## What

Integrate [andyleap/simplelog](https://github.com/andyleap/simplelog) (v0.1.0) — a self-hosted, S3-backed log aggregator — into the cluster.

- **agent** (DaemonSet, every node): tails container logs, enriches with K8s metadata, ships to the manager over DRPC. Runs as root with read-only host mounts (documented in-file) since reading root-owned host logs is incompatible with the cluster's nonroot norm.
- **manager** (StatefulSet, 1 replica): receives logs on `:9000`, archives segments to Linode Object Storage (the only durable store — `emptyDir` scratch, **no PVC**; catalog rebuilds from S3 on startup), serves the query UI on `:8080`.

The query UI has **no built-in auth**, so it's the first app fronted by the TinyOAuth ForwardAuth bouncer (#92) + a Pocket ID OIDC client (PKCE), restricted to the `simplelog-users` group, at `logs.andyleap.dev`.

## Changes

- `simplelog/` — manager StatefulSet + headless Service, agent DaemonSet + RBAC, S3 config ConfigMap, ForwardAuth Middleware, access policy, HTTPRoute (auth via Gateway API `ExtensionRef`).
- `terraform/simplelog.tf` — namespace, Object Storage bucket + key, `simplelog-s3` credentials Secret, Pocket ID client + group, Terraform-owned `tinyoauth-app-simplelog` config-ref ConfigMap (`client_id` via `.id`).
- `cluster/simplelog.yaml` + `cluster/kustomization.yaml` — ArgoCD Application.
- `kargo-projects/simplelog/` + `kargo-projects/kustomization.yaml` — Kargo promotion of both images (`master` → `live`).

Wildcard DNS (`*.andyleap.dev`) and the wildcard TLS cert already cover `logs.andyleap.dev` — no DNS/cert changes.

## Ordering

The OpenTofu apply runs on PR approval (before merge), so the namespace, S3 Secret, OIDC client, and config-ref ConfigMap exist before ArgoCD syncs the app.

## Verify after sync

- `kubectl -n simplelog get statefulset,daemonset,pods` — manager Ready, one agent per node.
- Manager logs show a clean S3 connection; objects appear in the `andyleap-dev-simplelog` bucket within a few minutes.
- `kubectl -n simplelog port-forward svc/simplelog-manager 8080:8080` → `/healthz` + `/v1/query`.
- Browse `https://logs.andyleap.dev` → TinyOAuth/Pocket ID login → query UI; unauthenticated requests are challenged.

> ⚠️ First app behind the TinyOAuth gate — the OIDC client shape (PKCE-public, callback `https://auth.andyleap.dev/callback`) follows the TinyOAuth docs but isn't yet proven in-cluster. Sanity-check first login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)