### PR TITLE
Scope Kargo Warehouse git subscriptions with includePaths

### DIFF
--- a/kargo-projects/argocd/warehouse.yaml
+++ b/kargo-projects/argocd/warehouse.yaml
@@ -14,3 +14,7 @@ spec:
         branch: master
         commitSelectionStrategy: NewestFromBranch
         strictSemvers: false
+        # Only build new Freight when this app's manifests change.
+        includePaths:
+          - cluster/argocd.yaml
+          - argocd

--- a/kargo-projects/cert-manager-webhook-linode/warehouse.yaml
+++ b/kargo-projects/cert-manager-webhook-linode/warehouse.yaml
@@ -22,3 +22,7 @@ spec:
         branch: master
         commitSelectionStrategy: NewestFromBranch
         strictSemvers: false
+        # Only build new Freight when this app's manifests change.
+        includePaths:
+          - cluster/cert-manager-webhook-linode.yaml
+          - cert-manager-webhook-linode

--- a/kargo-projects/cert-manager/warehouse.yaml
+++ b/kargo-projects/cert-manager/warehouse.yaml
@@ -14,3 +14,7 @@ spec:
         branch: master
         commitSelectionStrategy: NewestFromBranch
         strictSemvers: false
+        # Only build new Freight when this app's manifests change.
+        includePaths:
+          - cluster/cert-manager.yaml
+          - cert-manager

--- a/kargo-projects/cluster/warehouse.yaml
+++ b/kargo-projects/cluster/warehouse.yaml
@@ -12,3 +12,7 @@ spec:
         branch: master
         commitSelectionStrategy: NewestFromBranch
         strictSemvers: false
+        # Only build new Freight when the files this pipeline mirrors change.
+        includePaths:
+          - cluster/cluster.yaml
+          - cluster/kustomization.yaml

--- a/kargo-projects/kargo-projects/warehouse.yaml
+++ b/kargo-projects/kargo-projects/warehouse.yaml
@@ -12,3 +12,7 @@ spec:
         branch: master
         commitSelectionStrategy: NewestFromBranch
         strictSemvers: false
+        # Only build new Freight when the files this pipeline mirrors change.
+        includePaths:
+          - kargo-projects
+          - cluster/kargo-projects.yaml

--- a/kargo-projects/kargo/warehouse.yaml
+++ b/kargo-projects/kargo/warehouse.yaml
@@ -13,3 +13,7 @@ spec:
         branch: master
         commitSelectionStrategy: NewestFromBranch
         strictSemvers: false
+        # Only build new Freight when this app's manifests change.
+        includePaths:
+          - cluster/kargo.yaml
+          - kargo

--- a/kargo-projects/pocket-id/warehouse.yaml
+++ b/kargo-projects/pocket-id/warehouse.yaml
@@ -15,3 +15,7 @@ spec:
         branch: master
         commitSelectionStrategy: NewestFromBranch
         strictSemvers: false
+        # Only build new Freight when this app's manifests change.
+        includePaths:
+          - cluster/pocket-id.yaml
+          - pocket-id

--- a/kargo-projects/simplelog/warehouse.yaml
+++ b/kargo-projects/simplelog/warehouse.yaml
@@ -22,3 +22,7 @@ spec:
         branch: master
         commitSelectionStrategy: NewestFromBranch
         strictSemvers: false
+        # Only build new Freight when this app's manifests change.
+        includePaths:
+          - cluster/simplelog.yaml
+          - simplelog

--- a/kargo-projects/tinyoauth/warehouse.yaml
+++ b/kargo-projects/tinyoauth/warehouse.yaml
@@ -15,3 +15,7 @@ spec:
         branch: master
         commitSelectionStrategy: NewestFromBranch
         strictSemvers: false
+        # Only build new Freight when this app's manifests change.
+        includePaths:
+          - cluster/tinyoauth.yaml
+          - tinyoauth

--- a/kargo-projects/traefik-crds/warehouse.yaml
+++ b/kargo-projects/traefik-crds/warehouse.yaml
@@ -14,3 +14,7 @@ spec:
         branch: master
         commitSelectionStrategy: NewestFromBranch
         strictSemvers: false
+        # Only build new Freight when this app's manifests change.
+        includePaths:
+          - cluster/traefik-crds.yaml
+          - traefik-crds

--- a/kargo-projects/traefik/warehouse.yaml
+++ b/kargo-projects/traefik/warehouse.yaml
@@ -19,3 +19,7 @@ spec:
         branch: master
         commitSelectionStrategy: NewestFromBranch
         strictSemvers: false
+        # Only build new Freight when this app's manifests change.
+        includePaths:
+          - cluster/traefik.yaml
+          - traefik


### PR DESCRIPTION
## Problem

Every Kargo Warehouse subscribes to this repo (`andyleap-cluster/cluster.git`, branch `master`) with a `git` subscription that has **no path filtering**. As a result, *any* commit to the repo produces fresh git-based Freight for *all 11* Warehouses — even though each Warehouse's promotion only ever mirrors a small, fixed set of paths to the `live` branch. This means noisy Freight and unnecessary promotions/ArgoCD syncs for apps that didn't change.

## Change

Add an `includePaths` filter to each Warehouse's cluster.git git subscription, scoped to exactly the paths that the corresponding Stage's promotion template copies from `./src` (verified against each `stage.yaml`'s `copy` `inPath`s). Now a Warehouse only builds new git Freight when its own files change.

| Warehouse | `includePaths` |
|---|---|
| argocd, cert-manager, cert-manager-webhook-linode, kargo, pocket-id, simplelog, tinyoauth, traefik, traefik-crds | `cluster/<app>.yaml` + the `<app>/` manifest dir |
| cluster | `cluster/cluster.yaml` + `cluster/kustomization.yaml` (matches its narrow mirror promotion) |
| kargo-projects | `kargo-projects/` dir + `cluster/kargo-projects.yaml` |

Kargo treats `includePaths` entries as exact file/directory paths by default; selecting a directory implicitly includes everything under it, so no `glob:`/`regex:` prefix is needed.

## Out of scope (unchanged)

- Image and chart subscriptions.
- The upstream `linode/cert-manager-webhook-linode.git` git subscription.
- Stage/promotion templates.

## Verification

- `kubectl kustomize kargo-projects/` renders cleanly.
- Each `includePaths` list cross-checked against its Stage's `copy` `inPath`s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)