### PR TITLE
Wire up TinyOAuth /debug self-login OIDC client

### DIFF
--- a/terraform/tinyoauth-oidc.tf
+++ b/terraform/tinyoauth-oidc.tf
@@ -1,0 +1,42 @@
+# OIDC client + admin group for TinyOAuth's own authenticated /debug page.
+#
+# Unlike the per-app forward-auth clients (e.g. simplelog), this one logs an
+# admin into tinyoauth *itself*. tinyoauth exposes a synthetic "self app"
+# (reserved key _self_/_self_) that reuses the normal /start -> /callback flow,
+# gated to an admin group. The client_id is threaded into tinyoauth as
+# TINYOAUTH_ADMIN_CLIENT_ID (see tinyoauth.tf); the allowed group is set
+# non-secret in ../tinyoauth/configmap.yaml as admin_groups.
+#
+# Mechanics mirror terraform/simplelog.tf: PKCE-only public client, no
+# client_secret (tinyoauth authenticates the token exchange with an RFC 7523
+# JWT-bearer assertion signed by its Kubernetes ServiceAccount token). The
+# OAuth callback is served by tinyoauth on its shared auth host.
+
+# Only members of tinyoauth-admins may view /debug. Membership is assigned in
+# the Pocket ID UI; tinyoauth fails closed (/debug returns 404) if the group is
+# empty of the logged-in user.
+resource "pocketid_group" "tinyoauth_admins" {
+  name          = "tinyoauth-admins"
+  friendly_name = "TinyOAuth Admins"
+}
+
+# NB: do not set `client_id` here -- the trozz/pocketid provider sends it as
+# JSON `clientId`, but Pocket ID's API expects `id`, so the custom value is
+# silently ignored and Pocket ID auto-generates a UUID instead. The
+# auto-generated value is exposed via `.id` and threaded into the Secret in
+# tinyoauth.tf.
+resource "pocketid_client" "tinyoauth_debug" {
+  name = "TinyOAuth Debug"
+
+  callback_urls = [
+    "https://auth.andyleap.dev/callback",
+  ]
+
+  logout_callback_urls = [
+    "https://auth.andyleap.dev/sign_out",
+  ]
+
+  is_public    = true
+  pkce_enabled = true
+  launch_url   = "https://auth.andyleap.dev/debug"
+}

--- a/terraform/tinyoauth.tf
+++ b/terraform/tinyoauth.tf
@@ -13,9 +13,14 @@ resource "random_bytes" "tinyoauth_cookie_secret" {
   length = 32
 }
 
-# Injects TINYOAUTH_COOKIE_SECRET into the tinyoauth Deployment via envFrom.
-# The config.yaml ConfigMap (in git) intentionally omits cookie_secret;
-# TinyOAuth's applyEnvFallbacks fills it from this env var at startup.
+# Injects runtime env into the tinyoauth Deployment via envFrom. The config.yaml
+# ConfigMap (in git) intentionally omits these; TinyOAuth's applyEnvFallbacks
+# fills each empty field from its TINYOAUTH_<FIELD> env var at startup.
+#
+#   TINYOAUTH_COOKIE_SECRET   -> session encryption key (random, above)
+#   TINYOAUTH_ADMIN_CLIENT_ID -> OIDC client for the /debug self-login page;
+#                                Pocket ID's auto-generated client id, which
+#                                can't be hardcoded in git (see tinyoauth-oidc.tf).
 resource "kubernetes_secret" "tinyoauth_secret" {
   metadata {
     name      = "tinyoauth-secret"
@@ -23,6 +28,7 @@ resource "kubernetes_secret" "tinyoauth_secret" {
   }
 
   data = {
-    TINYOAUTH_COOKIE_SECRET = random_bytes.tinyoauth_cookie_secret.hex
+    TINYOAUTH_COOKIE_SECRET   = random_bytes.tinyoauth_cookie_secret.hex
+    TINYOAUTH_ADMIN_CLIENT_ID = pocketid_client.tinyoauth_debug.id
   }
 }

--- a/tinyoauth/configmap.yaml
+++ b/tinyoauth/configmap.yaml
@@ -14,5 +14,11 @@ data:
     annotation_prefix: "tinyoauth.andyleap.dev"
     namespace: "tinyoauth"
     service_account: "tinyoauth"
+    # Enables the authenticated /debug self-login page, restricted to members of
+    # this Pocket ID group. admin_client_id is intentionally absent here —
+    # injected at runtime via TINYOAUTH_ADMIN_CLIENT_ID (Terraform-managed,
+    # see terraform/tinyoauth-oidc.tf). Without an admin_client_id, /debug stays
+    # disabled (404); without an admin group/sub it also fails closed.
+    admin_groups: "tinyoauth-admins"
     # cookie_secret is intentionally absent — injected at runtime via
     # TINYOAUTH_COOKIE_SECRET from the tinyoauth-secret K8s Secret (Terraform-managed).


### PR DESCRIPTION
## Context

TinyOAuth **v0.2.0** ([PR #3](https://github.com/andyleap/tinyoauth/pull/3)) adds an authenticated `/debug` page (build info, redacted config, current session, resolver cache). Unlike the per-app forward-auth gates, `/debug` logs an admin into tinyoauth *itself* via a synthetic `_self_/_self_` app that reuses the existing `/start`→`/callback` flow. It's driven by three new config fields:

- `admin_client_id` — Pocket ID client for self-login
- `admin_groups` / `admin_subs` — CSV allowlist of who may view `/debug`

It **fails closed**: if `admin_client_id` is unset `/debug` is 404, and if no group/sub is set it stays disabled too (so an empty allowlist can't admit everyone).

This PR wires that up in the cluster config, mirroring the existing `simplelog` OIDC pattern.

## Changes

- **`terraform/tinyoauth-oidc.tf`** (new): a `pocketid_client` (`TinyOAuth Debug`) and a `pocketid_group` (`tinyoauth-admins`). PKCE-only public client — the token exchange is authenticated by tinyoauth's RFC 7523 SA JWT-bearer assertion, so there's no `client_secret`. Callback is served on the shared auth host (`https://auth.andyleap.dev/callback`).
- **`terraform/tinyoauth.tf`**: thread the client's auto-generated `.id` into the existing `tinyoauth-secret` as `TINYOAUTH_ADMIN_CLIENT_ID` (it can't be hardcoded in git; `applyEnvFallbacks` fills it at startup).
- **`tinyoauth/configmap.yaml`**: set `admin_groups: "tinyoauth-admins"` (non-secret) to enable `/debug` and restrict it to that group.

The `client_assertion`/PKCE mechanics and callback already match what existing per-app clients use, so no manifest/RBAC changes are needed.

## Image bump

v0.2.0 (which contains the debug page) is already published. The tinyoauth Kargo warehouse subscribes to `ghcr.io/andyleap/tinyoauth` SemVer `>=0.1.0 <1.0.0`, so the image bump auto-promotes to the `live` branch — **no image pin change in master** (consistent with every other app here).

## Post-merge manual step

Add the relevant user(s) to the **`tinyoauth-admins`** group in the Pocket ID UI. Until someone is a member, `/debug` returns 404 for them (fail-closed).

## Verification

- `kubectl kustomize tinyoauth/` renders cleanly.
- `tofu fmt -check` passes on the changed terraform.
- Review the `tofu plan` posted by the OpenTofu workflow (expect: new `pocketid_client`/`pocketid_group`, and `tinyoauth-secret` gaining `TINYOAUTH_ADMIN_CLIENT_ID`).
- After apply + Kargo promotes v0.2.0: visit `https://auth.andyleap.dev/debug` as a `tinyoauth-admins` member → OIDC login → debug page; as a non-member → 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)